### PR TITLE
Update fixed wing loadout

### DIFF
--- a/cScripts/Loadouts/CfgLoadouts_Crew.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_Crew.hpp
@@ -187,8 +187,8 @@ class CAV_HeloPilot : CommonBlufor {                // Helo Pilot
 class CAV_FixedPilot : CommonBlufor {				// Fixed Wing Pilot
     backpack[] = {""}; 						// must have access to tf_rt1523g
     uniform[] = {"U_B_PilotCoveralls"};
-    headgear[] = {"H_PilotHelmetHeli_B"};
-    vest[] = {""};
+    headgear[] = {"RHS_jetpilot_usaf"};
+    vest[] = {"V_TacVest_blk"};
 	
     primary[] = {"rhs_weap_mk18_bk"};
 	


### PR DESCRIPTION
Intended loadout no longer fits in the pilot uniform alone, added vest. There must have been a change to pilot coveralls capacity in cavpack 3.40.
Changed helmet to jet pilot helmet, as NVG is no longer built into the heli pilot helmet.