### PR TITLE
Correct Module Spelling

### DIFF
--- a/CfgSettings.hpp
+++ b/CfgSettings.hpp
@@ -2,7 +2,7 @@ class CfgSettings {
     isDebugMode                 =   0;      // 0 or 1 Add debug messages in the log (Default: 0)
     isMissionType               =   1;      // 0: Custom, 1: Operation, 2: Training (Default: 1)
     aiSystemDifficulty          =   0;      // 0: Standard, 1: Desert, 2: Dumb As Fuck (Default: 0)
-    use7cavZeusModuels          =   1;      // 0 or 1 Allow the misson to use the 7Cav moduel system. (Default: 1)
+    use7cavZeusModules          =   1;      // 0 or 1 Allow the misson to use the 7Cav moduel system. (Default: 1)
 
     // Hints and documents
     useStartHint                =   1;      // 0 or 1 Allow the mission to run the RedLightHint or TrainingMissionHint depends on mission type (Default: 1)

--- a/CfgSettings.hpp
+++ b/CfgSettings.hpp
@@ -2,7 +2,7 @@ class CfgSettings {
     isDebugMode                 =   0;      // 0 or 1 Add debug messages in the log (Default: 0)
     isMissionType               =   1;      // 0: Custom, 1: Operation, 2: Training (Default: 1)
     aiSystemDifficulty          =   0;      // 0: Standard, 1: Desert, 2: Dumb As Fuck (Default: 0)
-    use7cavZeusModules          =   1;      // 0 or 1 Allow the misson to use the 7Cav moduel system. (Default: 1)
+    use7cavZeusModules          =   1;      // 0 or 1 Allow the misson to use the 7Cav module system. (Default: 1)
 
     // Hints and documents
     useStartHint                =   1;      // 0 or 1 Allow the mission to run the RedLightHint or TrainingMissionHint depends on mission type (Default: 1)

--- a/cScripts/CavFnc/CfgFunctions.hpp
+++ b/cScripts/CavFnc/CfgFunctions.hpp
@@ -9,7 +9,7 @@ class cScripts {
         class initTrainingStartHint {};
         class initCustomStartHint {};
 
-        class initModuels {};
+        class initModules {};
 
         class initCuratorHeloFRIES {};
         class initCuratorHeloGetOutRL {};
@@ -69,12 +69,12 @@ class cScripts {
         class UH60TailNumber {}; //will be merged with "attachVehicleLabel"
         class flag {};
     };
-    class moduels {
-        file = "cScripts\cavFnc\functions\moduels";
-        class moduelCreateStarterCrate {};
-        //class moduelApplySupply {};
-        class moduelApplyTailNumber {};
-        class moduelReadyHelicopter {};
-        class moduelApplyFlag {};
+    class modules {
+        file = "cScripts\cavFnc\functions\modules";
+        class moduleCreateStarterCrate {};
+        //class moduleApplySupply {};
+        class moduleApplyTailNumber {};
+        class moduleReadyHelicopter {};
+        class moduleApplyFlag {};
     };
 };

--- a/cScripts/CavFnc/cScripts_preInit.sqf
+++ b/cScripts/CavFnc/cScripts_preInit.sqf
@@ -15,6 +15,6 @@ if (getNumber (missionConfigFile >> "CfgSettings" >> "useCustomInit") == 1) then
 
 };
 
-if (getNumber (missionConfigFile >> "CfgSettings" >> "use7cavZeusModuels") == 1) then {
-    call cScripts_fnc_initModuels;
+if (getNumber (missionConfigFile >> "CfgSettings" >> "use7cavZeusModules") == 1) then {
+    call cScripts_fnc_initModules;
 };

--- a/cScripts/CavFnc/functions/init/fn_initModules.sqf
+++ b/cScripts/CavFnc/functions/init/fn_initModules.sqf
@@ -11,11 +11,11 @@
 #include "..\script_component.hpp";
 
 ["7Cav Logistics", "Create Starter Crate",{
-    [(_this select 0)] call FUNC(moduelCreateStarterCrate);
+    [(_this select 0)] call FUNC(moduleCreateStarterCrate);
 }] call Ares_fnc_RegisterCustomModule;
 
 /*["7Cav Logistics", "Transform to Cav Supply",{
-    [(_this select 1)] call FUNC(moduelApplySupply);
+    [(_this select 1)] call FUNC(moduleApplySupply);
 }] call Ares_fnc_RegisterCustomModule;
 
 ["7Cav Logistics", "Transform to Vehicle",{
@@ -24,13 +24,13 @@
 */
 
 ["7Cav Helicopters", "Add Get Out Right/Left",{
-    [(_this select 1)] call FUNC(moduelReadyHelicopter);
+    [(_this select 1)] call FUNC(moduleReadyHelicopter);
 }] call Ares_fnc_RegisterCustomModule;
 
 ["7Cav Helicopters", "Add Tail Number",{
-    [(_this select 1)] call FUNC(moduelApplyTailNumber);
+    [(_this select 1)] call FUNC(moduleApplyTailNumber);
 }] call Ares_fnc_RegisterCustomModule;
 
 ["7Cav Misc", "Transform to Cav Flag",{
-    [(_this select 1)] call FUNC(moduelApplyFlag);
+    [(_this select 1)] call FUNC(moduleApplyFlag);
 }] call Ares_fnc_RegisterCustomModule;

--- a/cScripts/CavFnc/functions/init/fn_initModules.sqf
+++ b/cScripts/CavFnc/functions/init/fn_initModules.sqf
@@ -5,7 +5,7 @@
  * Arguments:
  *
  * Example:
- * call cScripts_fnc_initModuels;
+ * call cScripts_fnc_initModules;
  */
  
 #include "..\script_component.hpp";

--- a/cScripts/CavFnc/functions/modules/fn_moduleApplyFlag.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleApplyFlag.sqf
@@ -7,7 +7,7 @@
  * 1: Texture <STRING>
  *
  * Example:
- *  call cScripts_fnc_moduelApplyFlag;
+ *  call cScripts_fnc_moduleApplyFlag;
  */
 
 #include "..\script_component.hpp";

--- a/cScripts/CavFnc/functions/modules/fn_moduleApplyTailNumber.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleApplyTailNumber.sqf
@@ -7,7 +7,7 @@
  * 1: Texture <STRING>
  *
  * Example:
- *  call cScripts_fnc_moduelApplyTailNumber;
+ *  call cScripts_fnc_moduleApplyTailNumber;
  */
 
 #include "..\script_component.hpp";

--- a/cScripts/CavFnc/functions/modules/fn_moduleCreateStarterCrate.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleCreateStarterCrate.sqf
@@ -7,7 +7,7 @@
  * 0: Object <OBJECT>
  *
  * Example:
- *  this call moduelCreateStarterCrate;
+ *  this call moduleCreateStarterCrate;
  */
 
 #include "..\script_component.hpp";

--- a/cScripts/CavFnc/functions/modules/fn_moduleReadyHelicopter.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleReadyHelicopter.sqf
@@ -6,7 +6,7 @@
  * 0: Object <OBJECT>
  *
  * Example:
- *  call cScripts_fnc_moduelReadyHelicopter;
+ *  call cScripts_fnc_moduleReadyHelicopter;
  */
 
 #include "..\script_component.hpp";

--- a/init.sqf
+++ b/init.sqf
@@ -54,4 +54,4 @@
     
     TF_terrain_interception_coefficient         = 7.0; //Coefficient defining the level of radio signal interruption caused by terrain.
     
-/*           MODUELS            */
+/*           MODULES            */


### PR DESCRIPTION
Corrects all instances of the misspelling "moduel" to "module" throughout the project, including function files and folder. I've tested the branch ingame and get no compilation errors, though I can't test custom modules because Ares is no longer in the modpack which they depend on. (So this may all have been pointless...)