### PR TITLE
New jump script (fixed parameters)

### DIFF
--- a/cScripts/CavFnc/functions/systems/fn_addJump.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_addJump.sqf
@@ -17,8 +17,8 @@
 params [["_vehicle", objNull, [objNull]], ["_paraJumpATL",200], ["_paraChuteOpen_ATL",160]];
 
 _vehicle addAction [
-    "<t color='#800080'>Eject</t>",
-    {[_this select 0, _this select 1] call FUNC(doJump);
-    },[_paraJumpATL, _paraChuteOpen_ATL], 1.5, true, true, "",
-    "((_target getCargoIndex _this) != -1) && (((getPosATL _target) select 2) >= 200) && (_target animationPhase 'ramp_bottom' > 0.64)"
+    "<t color='#ef1fef'>Eject</t>",
+    {[_this select 0, _this select 1, _this select 3] call FUNC(doJump)
+	},_paraChuteOpen_ATL,1.5,true,true,"",
+    format ["((_target getCargoIndex _this) != -1) && (((getPosATL _target) select 2) >= %1) && (_target animationPhase 'ramp_bottom' > 0.64)", _paraJumpATL]
 ];

--- a/cScripts/CavFnc/functions/systems/fn_addJump.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_addJump.sqf
@@ -17,7 +17,7 @@
 params [["_vehicle", objNull, [objNull]], ["_paraJumpATL",200], ["_paraChuteOpen_ATL",160]];
 
 _vehicle addAction [
-    "<t color='#ef1fef'>Eject</t>",
+    "<t color='#ef1fef'>Jump</t>",
     {[_this select 0, _this select 1, _this select 3] call FUNC(doJump)
 	},_paraChuteOpen_ATL,1.5,true,true,"",
     format ["((_target getCargoIndex _this) != -1) && (((getPosATL _target) select 2) >= %1) && (_target animationPhase 'ramp_bottom' > 0.64)", _paraJumpATL]

--- a/cScripts/CavFnc/functions/systems/fn_doJump.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_doJump.sqf
@@ -20,7 +20,6 @@
 params [
     ["_vehicle", objNull, [objNull]],
     ["_player",player],
-    ["_paraJumpATL",200],
     ["_paraChuteOpen_ATL",160]
 ];
 


### PR DESCRIPTION
- Passes only the parachute open height into the jump action and script. The max jump height doesn't need to be passed since it's only used for the condition on the action.
- Changed the action condition to use the max jump height argument, it was previously hard coded.
- Increased action color brightness to be more readable (bright purple)
- Changed action text to "Jump" to avoid confusion with the built in Eject action