### PR TITLE
Fix aircraft radios

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -49,7 +49,6 @@
     TF_give_microdagr_to_soldier                = false;
     TF_defaultWestPersonalRadio                 = "tf_rf7800str";
     TF_defaultWestRiflemanRadio                 = "tf_anprc152";
-    TF_defaultWestAirborneRadio                 = "tf_rf7800str";
     TF_defaultWestBackpack                      = "tf_rt1523g_big_rhs";
     
     TF_terrain_interception_coefficient         = 7.0; //Coefficient defining the level of radio signal interruption caused by terrain.


### PR DESCRIPTION
Removes the value breaking aircraft radios in init.sqf.

TF_defaultWestAirborneRadio is the default LR radio for aircraft. Someone probably set it to the 7800 thinking it was referring to airborne infantry. Setting this to a short range radio breaks all aircraft builtin long range radio, since it can't find the 7800 in the list of long range radios. We don't need this value at all since the default is the tf_anarc210, the correct blufor aircraft radio.