### PR TITLE
Combat cameraman s5

### DIFF
--- a/cScripts/CfgLoadouts.hpp
+++ b/cScripts/CfgLoadouts.hpp
@@ -21,7 +21,7 @@ class CfgLoadouts {
     #include "Loadouts\CfgLoadouts_TrainingClass.hpp"
 
     #include "Loadouts\CfgLoadouts_S3.hpp"
-	#include "Loadouts\CfgLoadouts_S5.hpp"
+    #include "Loadouts\CfgLoadouts_S5.hpp"
 
     #include "Loadouts\CfgLoadouts_UserCustom.hpp"
 };

--- a/cScripts/CfgLoadouts.hpp
+++ b/cScripts/CfgLoadouts.hpp
@@ -21,6 +21,7 @@ class CfgLoadouts {
     #include "Loadouts\CfgLoadouts_TrainingClass.hpp"
 
     #include "Loadouts\CfgLoadouts_S3.hpp"
+	#include "Loadouts\CfgLoadouts_S5.hpp"
 
     #include "Loadouts\CfgLoadouts_UserCustom.hpp"
 };

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -19,8 +19,9 @@ class CAV_S5_Base : CommonBlufor {
     watch[] = {"ItemWatch"};
     insignia[] = {""};
     preLoadout = " \
-    [(_this select 0), 's3', 2, true, true] call cScripts_fnc_setPreInitPlayerSettings; \
-    (_this select 0) allowDamage false;\(_this select 0) setCaptive true;";
+    [(_this select 0), 's5', 2, 2, true] call cScripts_fnc_setPreInitPlayerSettings; \
+    (_this select 0) allowDamage false;\
+    (_this select 0) setCaptive true;";
     postLoadout = "[(_this select 0),true,true] call cScripts_fnc_setPostInitPlayerSettings;";
 };
 

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -2,7 +2,7 @@
 
 class CAV_S5_Base : CommonBlufor {
     uniform[] = {"U_C_Journalist"};
-	vest[] = {"V_Press_F"};
+    vest[] = {"V_Press_F"};
     backpack[] = {"B_AssaultPack_blk"};
     primary[] = {"","","","",""};
     secondary[] = {"","","","",""};

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -1,0 +1,31 @@
+//Waldie.A - Added 10/10/18 - sets up S5 cameraman
+
+class CAV_S5_Base : CommonBlufor {
+	uniform[] = {"U_C_Journalist"};
+	vest[] = {"V_Press_F"};
+	backpack[] = {"B_AssaultPack_blk"};
+	primary[] = {"","","","",""};
+	secondary[] = {"","","","",""};
+	launcher[] = {"","","","",""};
+	magazines[] = {""};
+	items[] = {"ACRE_PRC343","ACE_microDAGR","ACE_MapTools","ACE_Flashlight_XL50","ACRE_PRC152_ID_1","ACRE_PRC152_ID_2","ACE_morphine",3,"ACE_personalAidKit","ACE_elasticBandage",15,"ACE_quikclot",15,"ACE_EntrenchingTool","ACE_NVG_Wide"};
+	binoculars[] = {"ACE_Vector"};
+	compass[] = {"ItemCompass"};
+	goggles[] = {"rhs_googles_clear"};
+	gps[] = {"ItemGPS"};
+	headgear[] = {"H_PASGT_basic_blue_press_F"};
+	map[] = {"ItemMap"};
+	nvgs[] = {""};
+	watch[] = {"ItemWatch"};
+	insignia[] = {""};
+	preLoadout = " \
+    [(_this select 0), 's3', 2, true, true] call cScripts_fnc_setPreInitPlayerSettings; \
+    (_this select 0) allowDamage false;(_this select 0) setCaptive true;";
+	postLoadout = "[(_this select 0),true,true] call cScripts_fnc_setPostInitPlayerSettings;";
+};
+
+class S5 : CAV_S5_Base {};
+class S5_1 : CAV_S5_Base {};
+class S5_2 : CAV_S5_Base {};
+class S5_3 : CAV_S5_Base {};
+class S5_4 : CAV_S5_Base {};

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -20,7 +20,7 @@ class CAV_S5_Base : CommonBlufor {
     insignia[] = {""};
     preLoadout = " \
     [(_this select 0), 's3', 2, true, true] call cScripts_fnc_setPreInitPlayerSettings; \
-    (_this select 0) allowDamage false;(_this select 0) setCaptive true;";
+    (_this select 0) allowDamage false;\(_this select 0) setCaptive true;";
     postLoadout = "[(_this select 0),true,true] call cScripts_fnc_setPostInitPlayerSettings;";
 };
 

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -8,7 +8,7 @@ class CAV_S5_Base : CommonBlufor {
 	secondary[] = {"","","","",""};
 	launcher[] = {"","","","",""};
 	magazines[] = {""};
-	items[] = {"ACRE_PRC343","ACE_microDAGR","ACE_MapTools","ACE_Flashlight_XL50","ACRE_PRC152_ID_1","ACRE_PRC152_ID_2","ACE_morphine",3,"ACE_personalAidKit","ACE_elasticBandage",15,"ACE_quikclot",15,"ACE_EntrenchingTool","ACE_NVG_Wide"};
+	items[] = {"ACE_microDAGR","ACE_MapTools","ACE_Flashlight_XL50","ACRE_PRC152_ID_1","ACRE_PRC152_ID_2","ACE_morphine",3,"ACE_personalAidKit","ACE_elasticBandage",15,"ACE_quikclot",15,"ACE_EntrenchingTool","ACE_NVG_Wide"};
 	binoculars[] = {"ACE_Vector"};
 	compass[] = {"ItemCompass"};
 	goggles[] = {"rhs_googles_clear"};

--- a/cScripts/Loadouts/CfgLoadouts_S5.hpp
+++ b/cScripts/Loadouts/CfgLoadouts_S5.hpp
@@ -1,27 +1,27 @@
 //Waldie.A - Added 10/10/18 - sets up S5 cameraman
 
 class CAV_S5_Base : CommonBlufor {
-	uniform[] = {"U_C_Journalist"};
+    uniform[] = {"U_C_Journalist"};
 	vest[] = {"V_Press_F"};
-	backpack[] = {"B_AssaultPack_blk"};
-	primary[] = {"","","","",""};
-	secondary[] = {"","","","",""};
-	launcher[] = {"","","","",""};
-	magazines[] = {""};
-	items[] = {"ACE_microDAGR","ACE_MapTools","ACE_Flashlight_XL50","ACRE_PRC152_ID_1","ACRE_PRC152_ID_2","ACE_morphine",3,"ACE_personalAidKit","ACE_elasticBandage",15,"ACE_quikclot",15,"ACE_EntrenchingTool","ACE_NVG_Wide"};
-	binoculars[] = {"ACE_Vector"};
-	compass[] = {"ItemCompass"};
-	goggles[] = {"rhs_googles_clear"};
-	gps[] = {"ItemGPS"};
-	headgear[] = {"H_PASGT_basic_blue_press_F"};
-	map[] = {"ItemMap"};
-	nvgs[] = {""};
-	watch[] = {"ItemWatch"};
-	insignia[] = {""};
-	preLoadout = " \
+    backpack[] = {"B_AssaultPack_blk"};
+    primary[] = {"","","","",""};
+    secondary[] = {"","","","",""};
+    launcher[] = {"","","","",""};
+    magazines[] = {""};
+    items[] = {"ACE_microDAGR","ACE_MapTools","ACE_Flashlight_XL50","ACRE_PRC152_ID_1","ACRE_PRC152_ID_2","ACE_morphine",3,"ACE_personalAidKit","ACE_elasticBandage",15,"ACE_quikclot",15,"ACE_EntrenchingTool","ACE_NVG_Wide"};
+    binoculars[] = {"ACE_Vector"};
+    compass[] = {"ItemCompass"};
+    goggles[] = {"rhs_googles_clear"};
+    gps[] = {"ItemGPS"};
+    headgear[] = {"H_PASGT_basic_blue_press_F"};
+    map[] = {"ItemMap"};
+    nvgs[] = {""};
+    watch[] = {"ItemWatch"};
+    insignia[] = {""};
+    preLoadout = " \
     [(_this select 0), 's3', 2, true, true] call cScripts_fnc_setPreInitPlayerSettings; \
     (_this select 0) allowDamage false;(_this select 0) setCaptive true;";
-	postLoadout = "[(_this select 0),true,true] call cScripts_fnc_setPostInitPlayerSettings;";
+    postLoadout = "[(_this select 0),true,true] call cScripts_fnc_setPostInitPlayerSettings;";
 };
 
 class S5 : CAV_S5_Base {};


### PR DESCRIPTION
When merged this pull request will:
Edit the mentioned files.
Create a class for S5 combat camera that will, for any unit with the variable name S5 to S5_4:
- Change unit loadout to be that of a press journalist.
-  Remove unit damage
- Set post/pre unit init.
- Set captive state - invisible to AI
- When in combination with the correct composition allow access to zeus with limited usage (view only)