### PR TITLE
Fixed mission clan tag bug

### DIFF
--- a/cScripts/CavFnc/functions/systems/fn_getPlayerName.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_getPlayerName.sqf
@@ -27,7 +27,7 @@ _getType = toUpper(_getType);
 private _playerClan = "";
 
 // featch clan tag if in multiplayer
-if ((isMultiplayer) && (!isNil {squadParams _player})) then {
+if !(isNil {squadParams _player select 0 select 0}) then {
     _playerClan = squadParams _player select 0 select 0;
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- FIXED: Bug when a player did not have a clan tag got a return string `nil` instead of empty