### PR TITLE
Update fn_moduleCallEndex.sqf

### DIFF
--- a/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
@@ -1,7 +1,9 @@
 #include "..\script_component.hpp";
 /*
  * Author: CPL.Brostrom.A
+ * Edit by: CPL.Dunn.W
  * This module function print some hints and spam the chat with ENDEX. 
+ * Edit: 
  *
  * Arguments:
  * Nothing
@@ -11,15 +13,73 @@
  *
  * Public: No
  */
+ 
+//Module Options
+private _dialogResults = [
+	"Endex Options",
+	[
+		["Set Player Weapons To Safe", ["Yes", "No"], 0],
+		["Pacify AI", ["Yes", "No"], 0],
+		["Hint Players That Fire", ["Yes", "No"], 0]
+	]
+] call Ares_fnc_showChooseDialog;
 
-"ENDEX ENDEX ENDEX" remoteExecCall ["systemChat", 0];
-"DEBRIEF IN GAME" remoteExecCall ["systemChat", 0];
-"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", 0];
+if (count _dialogResults == 0) exitWith {};
 
+//handles results and turns them into booleans
+_dialogResults params ["_weaponsSafe", "_aiPacified", "_VCSTIME"];
+
+private _weaponsSafe = _weaponsSafe isEqualTo 0;
+private _aiPacified = _aiPacified isEqualTo 0;
+private _VCSTIME = _VCSTIME isEqualTo 0;
+
+
+//systemChat Endex message
+"ENDEX ENDEX ENDEX" remoteExecCall ["systemChat", 0]; //kept 0 for server logs
+"DEBRIEF IN GAME" remoteExecCall ["systemChat", 2];
+"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", 2];
+
+
+//hint Endex message
 private _title = "<t color='#ffc61a' size='1.2' shadow='1' shadowColor='#000000' align='center'>ENDEX ENDEX ENDEX!</t><br />";
 private _image = "<img size='5' image='cScripts\Data\Images\7CAV_LOGO_01.paa' align='center'/><br /><br />";
 private _text0 = "<t font='PuristaMedium' size='1.1'>Mission complete</t><br /><br />";
 private _text1 = "Hold your fire and report to your Squad Leaders for debriefing in game.<br />";
-private _text3 = "<t font='PuristaMedium' size='1.1'>Please safe your weapons!</t>";
+private _text3 = "<t font='PuristaMedium' size='1.1'>Please safe your weapons if you haven't already!</t>";
 
-parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", 0];
+parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", 2];
+
+
+//Change AI to careless (doesn't affected AI created after Endex) AND Set Safety to all Players
+{
+	if (isPlayer _x) then {
+		if (_weaponsSafe) then {
+			private _weapon = currentWeapon _x; 
+			private _safedWeapons = _x getVariable ['ace_safemode_safedWeapons', []]; 
+			if !(_weapon in _safedWeapons) then {  
+				[_x, currentWeapon _x, currentMuzzle _x] call ace_safemode_fnc_lockSafety; 
+			};
+		};
+	} else {
+		if (_aiPacified) then {
+			(group _x) setBehaviourStrong "CARELESS";
+		};
+	};
+} forEach allUnits;
+
+
+//hint players who fired 10 seconds after Endex
+if (_VCSTIME) then {
+	uiSleep 10;
+	hint_shooter_fnc = { //fnc to be called server side to execute locally on all players
+		player addEventHandler ["Fired", {  
+			private _message = ", Stop Right There Criminal Scum, You Have Fired After Endex. Hold Your Fire!"; //Edit message when Player fires
+			private _name = (name player); 
+	  
+			//to be called locally to be executed server side for all players to see
+			("Hold Fire "+_name+"!") remoteExecCall ["systemChat", 0]; //kept 0 for server logs
+			(_name+_message) remoteExecCall ["hint", 2]; 
+		}]; 
+	};
+	remoteExec ["hint_shooter_fnc", 2];
+};

--- a/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
@@ -3,7 +3,10 @@
  * Author: CPL.Brostrom.A
  * Edit by: CPL.Dunn.W
  * This module function print some hints and spam the chat with ENDEX. 
- * Edit: 
+ * It also gives the option to:
+ * -Set Players weapons to safe
+ * -Pacify all AI present
+ * -Hint and systemChat Players that fire 10 seconds after ENDEX is called
  *
  * Arguments:
  * Nothing
@@ -16,70 +19,76 @@
  
 //Module Options
 private _dialogResults = [
-	"Endex Options",
-	[
-		["Set Player Weapons To Safe", ["Yes", "No"], 0],
-		["Pacify AI", ["Yes", "No"], 0],
-		["Hint Players That Fire", ["Yes", "No"], 0]
-	]
+    "Endex Options",
+    [
+        ["Set Player Weapons To Safe", ["Yes", "No"], 0],
+        ["Pacify AI", ["Yes", "No"], 0],
+        ["Hint Players That Fire", ["Yes", "No"], 0]
+    ]
 ] call Ares_fnc_showChooseDialog;
 
 if (count _dialogResults == 0) exitWith {};
 
 //handles results and turns them into booleans
-_dialogResults params ["_weaponsSafe", "_aiPacified", "_VCSTIME"];
+_dialogResults params ["_weaponsSafe", "_aiPacified", "_holdFireMessage"];
 
 private _weaponsSafe = _weaponsSafe isEqualTo 0;
 private _aiPacified = _aiPacified isEqualTo 0;
-private _VCSTIME = _VCSTIME isEqualTo 0;
+private _holdFireMessage = _holdFireMessage isEqualTo 0;
 
 
 //systemChat Endex message
 "ENDEX ENDEX ENDEX" remoteExecCall ["systemChat", 0]; //kept 0 for server logs
-"DEBRIEF IN GAME" remoteExecCall ["systemChat", 2];
-"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", 2];
+"DEBRIEF" remoteExecCall ["systemChat", 0];
+"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", 0];
 
 
 //hint Endex message
 private _title = "<t color='#ffc61a' size='1.2' shadow='1' shadowColor='#000000' align='center'>ENDEX ENDEX ENDEX!</t><br />";
 private _image = "<img size='5' image='cScripts\Data\Images\7CAV_LOGO_01.paa' align='center'/><br /><br />";
 private _text0 = "<t font='PuristaMedium' size='1.1'>Mission complete</t><br /><br />";
-private _text1 = "Hold your fire and report to your Squad Leaders for debriefing in game.<br />";
+private _text1 = "Hold your fire and report to your Squad Leaders for debriefing.<br />";
 private _text3 = "<t font='PuristaMedium' size='1.1'>Please safe your weapons if you haven't already!</t>";
 
-parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", 2];
+parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", 0];
 
 
-//Change AI to careless (doesn't affected AI created after Endex) AND Set Safety to all Players
-{
-	if (isPlayer _x) then {
-		if (_weaponsSafe) then {
-			private _weapon = currentWeapon _x; 
-			private _safedWeapons = _x getVariable ['ace_safemode_safedWeapons', []]; 
-			if !(_weapon in _safedWeapons) then {  
-				[_x, currentWeapon _x, currentMuzzle _x] call ace_safemode_fnc_lockSafety; 
-			};
-		};
-	} else {
-		if (_aiPacified) then {
-			(group _x) setBehaviourStrong "CARELESS";
-		};
-	};
-} forEach allUnits;
+//Set Safety to all Players
+if (_weaponsSafe) then {
+    {
+        private _weapon = currentWeapon _x; 
+        private _safedWeapons = _x getVariable ['ace_safemode_safedWeapons', []]; 
+        if !(_weapon in _safedWeapons) then {  
+            [_x, currentWeapon _x, currentMuzzle _x] call ace_safemode_fnc_lockSafety; 
+        };
+    } forEach allPlayers;
+};
 
 
-//hint players who fired 10 seconds after Endex
-if (_VCSTIME) then {
-	uiSleep 10;
-	hint_shooter_fnc = { //fnc to be called server side to execute locally on all players
-		player addEventHandler ["Fired", {  
-			private _message = ", Stop Right There Criminal Scum, You Have Fired After Endex. Hold Your Fire!"; //Edit message when Player fires
-			private _name = (name player); 
-	  
-			//to be called locally to be executed server side for all players to see
-			("Hold Fire "+_name+"!") remoteExecCall ["systemChat", 0]; //kept 0 for server logs
-			(_name+_message) remoteExecCall ["hint", 2]; 
-		}]; 
-	};
-	remoteExec ["hint_shooter_fnc", 2];
+//Change AI to careless (doesn't affected AI created after Endex)
+if (_aiPacified) then { 
+    {
+        (group _x) setBehaviourStrong "CARELESS";
+    } forEach allUnits;
+};
+
+
+//hint players who fired 10 seconds after Endex 
+if (_holdFireMessage) then {
+    [
+        {
+            [player, 
+            ["fired", 
+                {
+                    private _message = ", Stop Right There Criminal Scum, You Have Fired After Endex. Hold Your Fire!"; //Edit message when Player fires
+                    private _name = (name player);
+              
+                    //to be called locally to be executed server side for all players to see
+                    ("Hold Fire "+_name+"!") remoteExecCall ["systemChat", 0]; //kept 0 for server logs
+                    (_name+_message) remoteExecCall ["hint", 0]; 
+                }
+            ]
+            ]remoteExec ["addEventHandler", 0];
+        }, 
+    [], 10] call CBA_fnc_waitAndExecute;
 };

--- a/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
+++ b/cScripts/CavFnc/functions/modules/fn_moduleCallEndex.sqf
@@ -1,12 +1,7 @@
 #include "..\script_component.hpp";
 /*
- * Author: CPL.Brostrom.A
- * Edit by: CPL.Dunn.W
- * This module function print some hints and spam the chat with ENDEX. 
- * It also gives the option to:
- * -Set Players weapons to safe
- * -Pacify all AI present
- * -Hint and systemChat Players that fire 10 seconds after ENDEX is called
+ * Author: CPL.Brostrom.A, CPL.Dunn.W
+ * This module function can disable ai set player weapon to safe and print some hints and spam the chat with ENDEX. 
  *
  * Arguments:
  * Nothing
@@ -38,10 +33,10 @@ private _holdFireMessage = _holdFireMessage isEqualTo 0;
 
 
 //systemChat Endex message
-"ENDEX ENDEX ENDEX" remoteExecCall ["systemChat", 0]; //kept 0 for server logs
-"DEBRIEF" remoteExecCall ["systemChat", 0];
-"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", 0];
-
+"ENDEX ENDEX ENDEX" remoteExecCall ["systemChat", -2];
+"DEBRIEF" remoteExecCall ["systemChat", -2];
+"LEADERS DEBRIEF IN CHANNEL BELOW" remoteExecCall ["systemChat", -2];
+"Mission have been endex" remoteExecCall [FUNC(logInfo), 0];
 
 //hint Endex message
 private _title = "<t color='#ffc61a' size='1.2' shadow='1' shadowColor='#000000' align='center'>ENDEX ENDEX ENDEX!</t><br />";
@@ -50,8 +45,7 @@ private _text0 = "<t font='PuristaMedium' size='1.1'>Mission complete</t><br /><
 private _text1 = "Hold your fire and report to your Squad Leaders for debriefing.<br />";
 private _text3 = "<t font='PuristaMedium' size='1.1'>Please safe your weapons if you haven't already!</t>";
 
-parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", 0];
-
+parseText(_title + _text0 + _image + _text1 + _text3) remoteExecCall ["hint", -2];
 
 //Set Safety to all Players
 if (_weaponsSafe) then {
@@ -59,36 +53,39 @@ if (_weaponsSafe) then {
         private _weapon = currentWeapon _x; 
         private _safedWeapons = _x getVariable ['ace_safemode_safedWeapons', []]; 
         if !(_weapon in _safedWeapons) then {  
-            [_x, currentWeapon _x, currentMuzzle _x] call ace_safemode_fnc_lockSafety; 
+            [_x, currentWeapon _x, currentMuzzle _x] call ace_safemode_fnc_lockSafety;
+            #ifdef DEBUG_MODE
+                [formatText["%1 weapon (%2) have been set to safe.", _x, _weapon]] call FUNC(logInfo);
+            #endif
         };
     } forEach allPlayers;
 };
 
 
-//Change AI to careless (doesn't affected AI created after Endex)
+//Set all AI behavior to careless and combat behavior Blue (doesn't affected AI created after Endex)
 if (_aiPacified) then { 
     {
         (group _x) setBehaviourStrong "CARELESS";
-    } forEach allUnits;
+        (group _x) setCombatMode "BLUE";
+        #ifdef DEBUG_MODE
+            [formatText["AI %1 group (%2) have been set to careless and blue.", _x, group _x]] call FUNC(logInfo);
+        #endif
+    } forEach ((allUnits) - (allPlayers));
 };
 
-
-//hint players who fired 10 seconds after Endex 
+//Adds a event handler that informs a players to hold fire
 if (_holdFireMessage) then {
     [
         {
             [player, 
-            ["fired", 
-                {
-                    private _message = ", Stop Right There Criminal Scum, You Have Fired After Endex. Hold Your Fire!"; //Edit message when Player fires
-                    private _name = (name player);
-              
-                    //to be called locally to be executed server side for all players to see
-                    ("Hold Fire "+_name+"!") remoteExecCall ["systemChat", 0]; //kept 0 for server logs
-                    (_name+_message) remoteExecCall ["hint", 0]; 
-                }
-            ]
-            ]remoteExec ["addEventHandler", 0];
+                ["fired", 
+                    {                
+                        format ["Player %1 have discharge his weapon during endex.", name player] call [FUNC(logInfo), 0];
+                        format ["Hold your fire %1!", name player] remoteExecCall ["systemChat", -2];
+                        hint format ["%1 hold your Fire! Your not allowed to discharge your weapon during Endex.", name player];
+                    }
+                ]
+            ] remoteExec ["addEventHandler", -2];
         }, 
     [], 10] call CBA_fnc_waitAndExecute;
 };


### PR DESCRIPTION
Added: 
-Players who fire after endex is called are now shown server wide through both hint and system chat. This is activated 10 seconds after endex is placed down
-All AI already spawned will be set to careless
-All players will have their safety set on
-All of these additions are optional using ares' Ares_fnc_showChooseDialog function --https://github.com/ArmaAchilles/Achilles/wiki/Custom-Modules

Note: Proposed still needs to be tested on a MP server but has been tested on SP and LAN SP.

Sry about any issues with formating/github. Not used to it. 