### PR TITLE
Delete junk around starter crate (fn_deleteDroppedObjects)

### DIFF
--- a/cScripts/CavFnc/CfgFunctions.hpp
+++ b/cScripts/CavFnc/CfgFunctions.hpp
@@ -93,6 +93,8 @@ class cScripts {
         class addQuickSelection {};
         class addInsigniaSelection {};
 
+        class deleteDroppedObjects {};
+
        // Plane jump
         class doJump {};
         class handleJump {};

--- a/cScripts/CavFnc/functions/logistics/fn_doStarterCrate.sqf
+++ b/cScripts/CavFnc/functions/logistics/fn_doStarterCrate.sqf
@@ -87,3 +87,6 @@ _object enableRopeAttach false;
 
 // Make object not loadable in ACE
 [_object, -1] call ace_cargo_fnc_setSize;
+
+// Make Starter crate clean junk around it
+[_object, 100] call FUNC(deleteDroppedObjects);

--- a/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
@@ -14,15 +14,15 @@
 
 params [
     ["_object", objNull, [objNull]],
-	["_radius", 50]
+    ["_radius", 50]
 ];
 
 _object setVariable ["_deleteRadius", _radius];
 
 _object addEventHandler ["ContainerClosed", {
-	params ["_object", "_unit"];
+    params ["_object", "_unit"];
 
-	private _radius = _object getVariable "_deleteRadius";
+    private _radius = _object getVariable "_deleteRadius";
 	{ deleteVehicle _x; } forEach nearestObjects [getpos _object,["WeaponHolder","GroundWeaponHolder"],_radius]
 
 }];

--- a/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
@@ -17,12 +17,7 @@ params [
     ["_radius", 50]
 ];
 
-_object setVariable ["_deleteRadius", _radius];
-
-_object addEventHandler ["ContainerClosed", {
+[_object, "ContainerClosed", {
     params ["_object", "_unit"];
-
-    private _radius = _object getVariable "_deleteRadius";
-    { deleteVehicle _x; } forEach nearestObjects [getpos _object,["WeaponHolder","GroundWeaponHolder"],_radius]
-
-}];
+    { deleteVehicle _x; } forEach nearestObjects [getpos _object, ["WeaponHolder", "GroundWeaponHolder"], _thisArgs];
+}, _radius] call CBA_fnc_addBISEventHandler;

--- a/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
@@ -1,0 +1,28 @@
+#include "..\script_component.hpp";
+/*
+ * This function deletes objects and junk on the ground in a given radius.
+ *
+ * Arguments:
+ * 0: Object
+ * 1: Radius
+ *
+ * Example:
+ * [this,100] call cScripts_fnc_deleteDroppedObjects
+ * [_object,100] call cScripts_fnc_deleteDroppedObjects
+ *
+ */
+
+params [
+    ["_object", objNull, [objNull]],
+	["_radius", 50]
+];
+
+_object setVariable ["_deleteRadius", _radius];
+
+_object addEventHandler ["ContainerClosed", {
+	params ["_object", "_unit"];
+
+	private _radius = _object getVariable "_deleteRadius";
+	{ deleteVehicle _x; } forEach nearestObjects [getpos _object,["WeaponHolder","GroundWeaponHolder"],_radius]
+
+}];

--- a/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
+++ b/cScripts/CavFnc/functions/systems/fn_deleteDroppedObjects.sqf
@@ -23,6 +23,6 @@ _object addEventHandler ["ContainerClosed", {
     params ["_object", "_unit"];
 
     private _radius = _object getVariable "_deleteRadius";
-	{ deleteVehicle _x; } forEach nearestObjects [getpos _object,["WeaponHolder","GroundWeaponHolder"],_radius]
+    { deleteVehicle _x; } forEach nearestObjects [getpos _object,["WeaponHolder","GroundWeaponHolder"],_radius]
 
 }];


### PR DESCRIPTION
Added fnc_deleteDroppedObjects.
This deletes junk and items on the floor in a given radius around the given object.
If attached to the starter crate junk will be deleted in a given radius (Default 50m) whenever player closes the crate inventory.

Usage:
[this,100] call cScripts_fnc_deleteDroppedObjects;
[_object, 100] call FUNC(deleteDroppedObjects);

This can be used to reduce server load caused by a huge number of junk dropped by players munching on the starter crate.