### PR TITLE
Make text in final instead of formating

### DIFF
--- a/cScripts/CavFnc/functions/diag/fn_log.sqf
+++ b/cScripts/CavFnc/functions/diag/fn_log.sqf
@@ -29,9 +29,9 @@ _componant = if ( _componant != "" ) then {format["(%1) ", _componant]} else {""
 
 _type = format ["%1", _type];
 
-private _logMessage = formatText ["%1%2%3: %4", _prefix, _componant, _type, _message];
+private _logMessage = format ["%1%2%3: %4", _prefix, _componant, _type, _message];
 
-diag_log _logMessage;
+diag_log text _logMessage;
 
 if (_sendToServer) then {
     [QEGVAR(event,logServer), _logMessage] call CBA_fnc_serverEvent;

--- a/cScripts/CavFnc/functions/init/fn_initEvents.sqf
+++ b/cScripts/CavFnc/functions/init/fn_initEvents.sqf
@@ -20,5 +20,5 @@
 if !(isServer) exitWith {};
 
 [QEGVAR(event,logServer), {
-    diag_log _this;
+    diag_log text _this;
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- CHANGED: Log message text formating is done in final step instead of the text formating stage