### PR TITLE
Uno life operation check

### DIFF
--- a/cScripts/cScripts_preInit.sqf
+++ b/cScripts/cScripts_preInit.sqf
@@ -23,6 +23,7 @@ GVAR(Radio) = false;
 EGVAR(Staging,ZoneStatus) = false;
 EGVAR(Staging,OverrideCompanyVar) = false;
 GVAR(isPlayer) = hasInterface || {_unit == player};
+GVAR(OneLife) = !isNil{(getArray (missionconfigfile >> "respawnTemplates") select 0) == "ace_spectator"};
 
 // Make settings name
 private _cScriptSettings = "cScripts Mission Settings";

--- a/cScripts/functions/init/fn_init_staging.sqf
+++ b/cScripts/functions/init/fn_init_staging.sqf
@@ -96,8 +96,7 @@ player addEventHandler ["InventoryClosed", {
 }];
 
 // Menu option
-[player, true, _category] call FUNC(addReGear);
-[player, _category] call FUNC(addHeal);
+[player, _category] call FUNC(addReGear);
 [player, _category] call FUNC(addInsigniaSelectionList);
 [player, true, "ACE_SelfActions"] call FUNC(setupLoadoutSelection);
 [_category] call FUNC(addArsenal);

--- a/cScripts/functions/init/fn_init_staging.sqf
+++ b/cScripts/functions/init/fn_init_staging.sqf
@@ -97,6 +97,7 @@ player addEventHandler ["InventoryClosed", {
 
 // Menu option
 [player, _category] call FUNC(addReGear);
+if !(GVAR(OneLife)) then {[player, _category] call FUNC(addHeal)};
 [player, _category] call FUNC(addInsigniaSelectionList);
 [player, true, "ACE_SelfActions"] call FUNC(setupLoadoutSelection);
 [_category] call FUNC(addArsenal);

--- a/cScripts/functions/logistics/fn_doStarterCrate.sqf
+++ b/cScripts/functions/logistics/fn_doStarterCrate.sqf
@@ -62,9 +62,8 @@ _object addAction [format ["<img image='cScripts\Data\Icon\icon_00.paa' /> 7th C
 
 // Call ReGear Option
 if (_reGearOption) then {
-    [_object, _reHealOption] call FUNC(addReGear);
+    [_object] call FUNC(addReGear);
 };
-
 // Call addHeal option
 if (_reHealOption) then {
     [_object] call FUNC(addHeal);

--- a/cScripts/functions/systems/fn_addHeal.sqf
+++ b/cScripts/functions/systems/fn_addHeal.sqf
@@ -20,16 +20,20 @@ if (!isPlayer _object) then {
     _object addAction ["   <t color='#ff3333'>Heal</t>", {
         params ["_target", "_caller", "_actionId", "_arguments"];
         [_target, _caller] call ace_medical_treatment_fnc_fullHeal;
-    }, [], 1.5, true, true, "", "true", 5];
+        [[],["You have been healed"], [""], [""]] call CBA_fnc_notify;
+    }, [], 1.5, true, true, "", QUOTE(!GVAR(OneLife)), 5];
 };
 
 // Make ACE Interaction for ReGear
 private _Icon = "\z\ACE\addons\medical_gui\ui\cross.paa";
 private _healStatement = {
     [_this select 0, player] call ace_medical_treatment_fnc_fullHeal;
+    [[],["You have been healed"], [""], [""]] call CBA_fnc_notify;
 };
 
 private _actionType = if (isPlayer _object) then {1} else {0};
 
-private _healAction = [QEGVAR(Actions,HealAction), "Heal", "\z\ACE\addons\medical_gui\ui\cross.paa", _healStatement, {true}] call ace_interact_menu_fnc_createAction;
+private _healAction = [QEGVAR(Actions,HealAction), "Heal", "\z\ACE\addons\medical_gui\ui\cross.paa", _healStatement, {!GVAR(OneLife)}] call ace_interact_menu_fnc_createAction;
 [_object, _actionType, _category, _healAction] call ace_interact_menu_fnc_addActionToObject;
+
+true

--- a/cScripts/functions/systems/fn_addReGear.sqf
+++ b/cScripts/functions/systems/fn_addReGear.sqf
@@ -5,8 +5,7 @@
  *
  * Arguments:
  * 0: Object <OBJECT>
- * 1: Allow Heal <BOOL> (Optional)      // No longer in use
- * 2: ACE Category <ARRAY> (Optional)
+ * 1: ACE Category <ARRAY> (Optional)
  *
  * Example:
  * [this] call cScripts_fnc_addReGear

--- a/cScripts/functions/systems/fn_addReGear.sqf
+++ b/cScripts/functions/systems/fn_addReGear.sqf
@@ -1,22 +1,21 @@
 #include "..\script_component.hpp";
 /*
  * Author: CPL.Brostrom.A
- * This adds a reGear selection option. The script reApplyes the players start loadout. But may also heal you if option is allowed.
+ * This adds a reGear selection option. The script reApplyes the players start loadout.
  *
  * Arguments:
  * 0: Object <OBJECT>
- * 1: Allow Heal <BOOL> (Optional)
+ * 1: Allow Heal <BOOL> (Optional)      // No longer in use
  * 2: ACE Category <ARRAY> (Optional)
  *
  * Example:
  * [this] call cScripts_fnc_addReGear
- * [this, true] call cScripts_fnc_addReGear
- * [this, true, ["ACE_MainActions"]] call cScripts_fnc_addReGear
+ * [this] call cScripts_fnc_addReGear
+ * [this, ["ACE_MainActions"]] call cScripts_fnc_addReGear
  */
 
 params [
     ["_object", objNull, [objNull]],
-    ["_doHeal", true],
     ["_category", ["ACE_MainActions"], [["ACE_MainActions"]]]
 ];
 
@@ -24,41 +23,20 @@ params [
 if (!isPlayer _object) then {
     _object addAction ["   <t color='#ffcc33'>ReGear</t>", {
         params ["_target", "_caller", "_actionId", "_arguments"];
-        _arguments params ["_doHeal"];
         [QEGVAR(gear,applyLoadout)] call CBA_fnc_localEvent;
-
-
-        if (_doHeal) then {
-            [_target, player] call ace_medical_treatment_fnc_fullHeal;
-        };
-
-        [
-            [],
-            ["You have rearmed"],
-            [""],
-            [""]
-        ] call CBA_fnc_notify;
-
-    }, [_doHeal], 1.5, true, true, "", "true", 5];
+        [[],["You have been rearmed"], [""], [""]] call CBA_fnc_notify;
+    }, [], 1.5, true, true, "", "true", 5];
 };
 
 // Make ACE Interaction for ReGear
 private _Icon = "cScripts\Data\Icon\icon_00.paa";
 private _regearStatement = {
     [QEGVAR(gear,applyLoadout)] call CBA_fnc_localEvent;
-
-    if (_doHeal) then {
-        [_this select 0, player] call ace_medical_treatment_fnc_fullHeal;
-    };
-
-    [
-        [],
-        ["You have rearmed"],
-        [""],
-        [""]
-    ] call CBA_fnc_notify;
+    [[],["You have been rearmed"], [""], [""]] call CBA_fnc_notify;
 };
 private _actionType = if (isPlayer _object) then {1} else {0};
 
 private _regearAction = ["cScriptsReGearAce", "ReGear", _Icon, _regearStatement, {true}] call ace_interact_menu_fnc_createAction;
 [_object, _actionType, _category, _regearAction] call ace_interact_menu_fnc_addActionToObject;
+
+true


### PR DESCRIPTION
**When merged this pull request will:**
- ADDED: Global variable to check for One Life Ops
- CHANGED: Regear no loger heal players
- CHANGED: Regear parameter no does not contain heal boolean.
- CHANGED: Heal actions are now hidden when one life ops are enabled.