### PR TITLE
Added bindable shortcut for vehicle exit

### DIFF
--- a/cScripts/functions/mission/fn_addGetOutHelo.sqf
+++ b/cScripts/functions/mission/fn_addGetOutHelo.sqf
@@ -32,14 +32,14 @@ if (_useColor) then {
 _vehicle addAction [
     _leftSide,
     {[_this select 0, true] call FUNC(doGetOutHeloSide)},
-    0, 1.5, true, true, "User1",
+    0, 1.5, true, true, "User12",
     "(_target getCargoIndex _this) != -1"
 ];
 
 _vehicle addAction [
     _rightSide,
     {[_this select 0, false] call FUNC(doGetOutHeloSide)},
-    0, 1.5, true, true, "User2",
+    0, 1.5, true, true, "User13",
     "(_target getCargoIndex _this) != -1"
 ];
 

--- a/cScripts/functions/mission/fn_addGetOutHelo.sqf
+++ b/cScripts/functions/mission/fn_addGetOutHelo.sqf
@@ -32,14 +32,14 @@ if (_useColor) then {
 _vehicle addAction [
     _leftSide,
     {[_this select 0, true] call FUNC(doGetOutHeloSide)},
-    0, 1.5, true, true, "",
+    0, 1.5, true, true, "User1",
     "(_target getCargoIndex _this) != -1"
 ];
 
 _vehicle addAction [
     _rightSide,
     {[_this select 0, false] call FUNC(doGetOutHeloSide)},
-    0, 1.5, true, true, "",
+    0, 1.5, true, true, "User2",
     "(_target getCargoIndex _this) != -1"
 ];
 


### PR DESCRIPTION
**When merged this pull request will:**
- Added bindable shortcut for vehicle exit
  - Keybinding uses `User Acrion 12` for left and `UserAction 13` for right
![image](https://github.com/7Cav/cScripts/assets/13811113/0472c421-b3a1-47a3-8465-759a94d198e3)
