### PR TITLE
Fixed spelling error in stryker Anti-Air pylon

### DIFF
--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -180,7 +180,7 @@ private _getVehiclePylons = _pylons getOrDefault [_vehicleKind, []];
 if (count _getVehiclePylons == 0) exitWith {[]};
 private _pylon = _getVehiclePylons getOrDefault [_loadout, []];
 
-if (_pylon isEqualTo []) then {
+if (count _pylon == 0) then {
     [format ["%1 Does not exist for selected kind of %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
 };
 

--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -180,4 +180,10 @@ private _getVehiclePylons = _pylons getOrDefault [_vehicleKind, []];
 if (count _getVehiclePylons == 0) exitWith {[]};
 private _pylon = _getVehiclePylons getOrDefault [_loadout, []];
 
+#ifdef DEBUG_MODE
+    if (_pylon == []) then {
+        [format ["%1 not found in list of loadouts for %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
+    };
+#endif
+
 _pylon;

--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -125,7 +125,7 @@ private _rhsusf_m1a1tank_base = createHashMapFromArray [
 
 // _APC_Wheeled_03_base_F
 private _APC_Wheeled_03_base_F = createHashMapFromArray [
-    ["AntiArmor", [
+    ["antiarmor", [
         ["SmokeLauncherMag",[0,0],6],
         ["140Rnd_30mm_MP_shells_Tracer_Red",[0],140],
         ["60Rnd_30mm_APFSDS_shells_Tracer_Red",[0],60],
@@ -136,7 +136,7 @@ private _APC_Wheeled_03_base_F = createHashMapFromArray [
         ["2Rnd_GAT_missiles",[0],2],
         ["2Rnd_GAT_missiles",[0],2]  
     ]],
-    [ "AntiAir", [
+    [ "antiair", [
         ["SmokeLauncherMag",[0,0],6],
         ["2000Rnd_762x51_Belt_T_Red",[0],2000],
         ["2000Rnd_762x51_Belt_T_Red",[0],2000],
@@ -156,7 +156,7 @@ private _APC_Wheeled_03_base_F = createHashMapFromArray [
         ["60Rnd_30mm_APFSDS_shells_Tracer_Red",[0],60],
         ["60Rnd_30mm_APFSDS_shells_Tracer_Red",[0],60]
     ]],
-    ["Assault",[
+    ["assault",[
         ["SmokeLauncherMag",[0,0],6],
         ["140Rnd_30mm_MP_shells_Tracer_Red",[0],140],
         ["140Rnd_30mm_MP_shells_Tracer_Red",[0],140],
@@ -175,10 +175,6 @@ private _pylons = createHashMapFromArray [
     ["rhsusf_m1a1tank_base", _rhsusf_m1a1tank_base],
     ["APC_Wheeled_03_base_F", _APC_Wheeled_03_base_F]
 ];
-
-#ifdef DEBUG_MODE
-    [format ["%1 not found in list of loadouts for %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
-#endif
 
 private _getVehiclePylons = _pylons getOrDefault [_vehicleKind, []];
 if (count _getVehiclePylons == 0) exitWith {[]};

--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -181,7 +181,7 @@ if (count _getVehiclePylons == 0) exitWith {[]};
 private _pylon = _getVehiclePylons getOrDefault [_loadout, []];
 
 #ifdef DEBUG_MODE
-    if (_pylon == []) then {
+    if (_pylon isEqualTo []) then {
         [format ["%1 not found in list of loadouts for %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
     };
 #endif

--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -180,10 +180,8 @@ private _getVehiclePylons = _pylons getOrDefault [_vehicleKind, []];
 if (count _getVehiclePylons == 0) exitWith {[]};
 private _pylon = _getVehiclePylons getOrDefault [_loadout, []];
 
-#ifdef DEBUG_MODE
-    if (_pylon isEqualTo []) then {
-        [format ["%1 not found in list of loadouts for %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
-    };
-#endif
+if (_pylon isEqualTo []) then {
+    [format ["%1 Does not exist for selected kind of %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
+};
 
 _pylon;

--- a/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_getPylon.sqf
@@ -176,6 +176,10 @@ private _pylons = createHashMapFromArray [
     ["APC_Wheeled_03_base_F", _APC_Wheeled_03_base_F]
 ];
 
+#ifdef DEBUG_MODE
+    [format ["%1 not found in list of loadouts for %2.", _loadout, _vehicleKind], "Vehicle Pylon"] call FUNC(warning);
+#endif
+
 private _getVehiclePylons = _pylons getOrDefault [_vehicleKind, []];
 if (count _getVehiclePylons == 0) exitWith {[]};
 private _pylon = _getVehiclePylons getOrDefault [_loadout, []];

--- a/cScripts/functions/vehicle/fn_vehicle_setupPylonCategories.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_setupPylonCategories.sqf
@@ -35,8 +35,8 @@ if (_vehicle iskindOf "rhsusf_m1a1tank_base") then {
 if (_vehicle iskindOf "APC_Wheeled_03_base_F") then {
     _pylonList = [
         // TypeOf,                DisplayName,  Name,           Icon
-        ["APC_Wheeled_03_base_F", "AntiArmor",  "antiarmor",    ""],
-        ["APC_Wheeled_03_base_F", "AntiAir",    "antiair",      ""],
+        ["APC_Wheeled_03_base_F", "Anti-Armor",  "antiarmor",    ""],
+        ["APC_Wheeled_03_base_F", "Anti-Air",    "antiair",      ""],
         ["APC_Wheeled_03_base_F", "Assault",    "assault",      ""],
         ["APC_Wheeled_03_base_F", "Default",    "default",      ""]
     ];

--- a/cScripts/functions/vehicle/fn_vehicle_setupPylonCategories.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_setupPylonCategories.sqf
@@ -35,9 +35,9 @@ if (_vehicle iskindOf "rhsusf_m1a1tank_base") then {
 if (_vehicle iskindOf "APC_Wheeled_03_base_F") then {
     _pylonList = [
         // TypeOf,                DisplayName,  Name,           Icon
-        ["APC_Wheeled_03_base_F", "AntiArmor",  "AntiArmor",    ""],
-        ["APC_Wheeled_03_base_F", "AntiAir",    "AnitAir",      ""],
-        ["APC_Wheeled_03_base_F", "Assault",    "Assault",      ""],
+        ["APC_Wheeled_03_base_F", "AntiArmor",  "antiarmor",    ""],
+        ["APC_Wheeled_03_base_F", "AntiAir",    "antiair",      ""],
+        ["APC_Wheeled_03_base_F", "Assault",    "assault",      ""],
         ["APC_Wheeled_03_base_F", "Default",    "default",      ""]
     ];
 };


### PR DESCRIPTION
ref #913 

**When merged this pull request will:**
- Fixes the spelling error preventing the `Anti-Air` pylon from being loaded.
- Adds a block for debugging when a similar error is thrown. This is active only when debug mode is enabled.
