### PR TITLE
Fixed typeName syntax in fn_testing_loadoutArrays

### DIFF
--- a/cScripts/functions/testing/fn_testing_loadoutArrays.sqf
+++ b/cScripts/functions/testing/fn_testing_loadoutArrays.sqf
@@ -116,7 +116,7 @@ private _classnameList = configProperties [missionconfigfile >> "CfgLoadouts", "
                 };
                 {
                     if (typeName _x != "STRING") then { 
-                        [format["FAILED: Loadout %1 Assigned Items expected item in string got %2", _class, _x typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                        [format["FAILED: Loadout %1 Assigned Items expected item in string got %2", _class, typeName _x], "FAILED", true, false, "TESTING"] call FUNC(log);
                         _return = false;
                     }
                 } forEach _element;

--- a/cScripts/functions/testing/fn_testing_loadoutArrays.sqf
+++ b/cScripts/functions/testing/fn_testing_loadoutArrays.sqf
@@ -53,61 +53,61 @@ private _classnameList = configProperties [missionconfigfile >> "CfgLoadouts", "
         switch (_forEachIndex) do {
             private _element = _x;
             case 0: {
-                if (_element typeName != "ARRAY") then { 
+                if (typeName _element != "ARRAY") then { 
                     [format["FAILED: Loadout %1 Primary Weapon is not a array got %2", _class, _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 1: {
-                if (_element typeName != "ARRAY") then { 
+                if (typeName _element != "ARRAY") then { 
                     [format["FAILED: Loadout %1 Secondary Weapon is not a array got %2", _class, _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 2: {
-                if (_element typeName != "ARRAY") then { 
+                if (typeName _element != "ARRAY") then { 
                     [format["FAILED: Loadout %1 Handgun Weapon is not a array got %2", _class, _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 3: {
-                if (_element typeName != "ARRAY") then { 
-                    [format["FAILED: Loadout %1 Uniform is not a array got %2", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "ARRAY") then { 
+                    [format["FAILED: Loadout %1 Uniform is not a array got %2", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 4: {
-                if (_element typeName != "ARRAY") then { 
-                    [format["FAILED: Loadout %1 Vest is not a array got %2", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "ARRAY") then { 
+                    [format["FAILED: Loadout %1 Vest is not a array got %2", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             case 5: {
-                if (_element typeName != "ARRAY") then { 
-                    [format["FAILED: Loadout %1 Backpack is not a array got %2", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "ARRAY") then { 
+                    [format["FAILED: Loadout %1 Backpack is not a array got %2", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 6: {
-                if (_element typeName != "STRING") then { 
-                    [format["FAILED: Loadout %1 Headgear is not a string got %1", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "STRING") then { 
+                    [format["FAILED: Loadout %1 Headgear is not a string got %1", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 7: {
-                if (_element typeName != "STRING") then { 
-                    [format["FAILED: Loadout %1 Goggles/Facewear is not a string got %1", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "STRING") then { 
+                    [format["FAILED: Loadout %1 Goggles/Facewear is not a string got %1", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 8: {
-                if (_element typeName != "ARRAY") then { 
-                    [format["FAILED: Loadout %1 Binoculars is not a array got %2", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "ARRAY") then { 
+                    [format["FAILED: Loadout %1 Binoculars is not a array got %2", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
             };
             case 9: {
-                if (_element typeName != "ARRAY") then { 
-                    [format["FAILED: Loadout %1 Assigned Items is not a array got %2", _class, _element typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
+                if (typeName _element != "ARRAY") then { 
+                    [format["FAILED: Loadout %1 Assigned Items is not a array got %2", _class, typeName _element], "FAILED", true, false, "TESTING"] call FUNC(log);
                     _return = false;
                 };
                 if (count _element != 6) then { 
@@ -115,7 +115,7 @@ private _classnameList = configProperties [missionconfigfile >> "CfgLoadouts", "
                     _return = false;
                 };
                 {
-                    if (_x typeName != "STRING") then { 
+                    if (typeName _x != "STRING") then { 
                         [format["FAILED: Loadout %1 Assigned Items expected item in string got %2", _class, _x typeName], "FAILED", true, false, "TESTING"] call FUNC(log);
                         _return = false;
                     }


### PR DESCRIPTION
**When merged this pull request will:**
- Fix syntax of `typeName` command