### PR TITLE
Fixed: Removed zeus event handlers for vehicle init 

### DIFF
--- a/cScripts/functions/init/fn_init_eventHandlers.sqf
+++ b/cScripts/functions/init/fn_init_eventHandlers.sqf
@@ -15,51 +15,6 @@ INFO("InitEventHandlers","Creating Global EventHandlers");
     call FUNC(getAttendance);
 }] call CBA_fnc_addEventHandler;
 
-[QGVAR(setCuratorEventHandlers), {
-    _this params ["_player"];
-    if (!isNil{_x getVariable QEGVAR(player,zeus)}) exitWith {};
-        
-
-    _player addEventHandler ["CuratorObjectPlaced", {
-        params ["", "_vehicle"];
-        INFO("Curator", "Object (%1) placed by curator, Applying functions", _vehicle);
-        [{
-            _this params ["_vehicle"];
-            if (_vehicle iskindOf "man") exitWith {};
-            _vehicle remoteExec [QEFUNC(vehicle,reset), 0, true]; 
-            _vehicle remoteExec [QEFUNC(vehicle,addFunctions), -2, true];
-            _vehicle remoteExec [QEFUNC(vehicle,addInventory), 2];
-            _vehicle remoteExec [QEFUNC(vehicle,addDefaultLoadout), 2];
-            _vehicle remoteExec [QEFUNC(vehicle,addCosmetics), 2];
-            _vehicle remoteExec [QEFUNC(vehicle,addStagingActions), -2];
-            _vehicle remoteExec [QEFUNC(vehicle,addRadio), 2];
-        }, [_vehicle], 1] call CBA_fnc_waitAndExecute;
-
-    }];
-
-    _player setVariable [QEGVAR(player,zeus), true];
-}] call CBA_fnc_addEventHandler;
-
-
-
-INFO("InitEventHandlers","Creating Client EventHandlers");
-if (GVAR(isPlayer)) then {
-
-    ["ace_zeusCreated", {
-        _this params ["_zeus"];
-        LOG_1("CuratorCreate_ACE", "ACE curator created");
-        [QGVAR(setCuratorEventHandlers), [_zeus]] call CBA_fnc_targetEvent;
-    }] call CBA_fnc_addEventHandler;
-    
-    ["zen_common_createZeus", {
-        _this params ["_zeus"];
-        LOG_1("CuratorCreate_ZEN", "ZEN curator created");
-        [QGVAR(setCuratorEventHandlers), [_zeus]] call CBA_fnc_targetEvent;
-    }] call CBA_fnc_addEventHandler;
-
-};
-
-
 // Server Events
 if (!isServer) exitWith {};
 INFO("InitEventHandlers","Creating Server EventHandlers");

--- a/cScripts/functions/init/fn_init_vehicle.sqf
+++ b/cScripts/functions/init/fn_init_vehicle.sqf
@@ -16,21 +16,25 @@ INFO("InitVehicle","Applying Event Handers (init) to vehicles for function expan
 
 if !(EGVAR(Settings,enableVehicleSystem)) exitWith {};
 
-["AllVehicles", "init", {
-    _this params ["_vehicle"];
-    if (_vehicle iskindOf "man") exitWith {};
-    [{
-        _this params ["_vehicle"];
-        _vehicle call EFUNC(vehicle,addFunctions);
-        _vehicle call EFUNC(vehicle,addInventory);
-        _vehicle call EFUNC(vehicle,addDefaultLoadout);
-        _vehicle call EFUNC(vehicle,addCosmetics);
-        _vehicle call EFUNC(vehicle,addStagingActions);
-        _vehicle call EFUNC(vehicle,addRadio);
-    }, [_vehicle], 1] call CBA_fnc_waitAndExecute;
-}, true, [], true] call CBA_fnc_addClassEventHandler;
+//Events tied to init
+[QEGVAR(vehicle,functionsEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addFunctions)} ] call CBA_fnc_addEventHandler;
+[QEGVAR(vehicle,inventoryEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addInventory)} ] call CBA_fnc_addEventHandler;
+[QEGVAR(vehicle,loadoutEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addDefaultLoadout)} ] call CBA_fnc_addEventHandler;
+[QEGVAR(vehicle,cosmeticsEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addCosmetics)} ] call CBA_fnc_addEventHandler;
+[QEGVAR(vehicle,stagingEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addStagingActions)} ] call CBA_fnc_addEventHandler;
+[QEGVAR(vehicle,radioEH), {params ["_vehicle"]; _vehicle call EFUNC(vehicle,addStagingActions)} ] call CBA_fnc_addEventHandler;
 
-{
-    if (!isNil{_x getVariable QEGVAR(player,zeus)}) exitWith {};
-    [QGVAR(setCuratorEventHandlers), [_x]] call CBA_fnc_targetEvent;
-} forEach allCurators;
+
+["AllVehicles", "initPost", {
+    params ["_vehicle"];
+    // [{
+        // params ["_vehicle"];
+    // [QEGVAR(vehicle,functionsEH), [_vehicle]] call CBA_fnc_localEvent;
+    _vehicle call EFUNC(vehicle,addFunctions);
+    [QEGVAR(vehicle,inventoryEH), [_vehicle]] call CBA_fnc_localEvent;
+    [QEGVAR(vehicle,loadoutEH), [_vehicle]] call CBA_fnc_serverEvent;
+    [QEGVAR(vehicle,cosmeticsEH), [_vehicle]] call CBA_fnc_localEvent;
+    [QEGVAR(vehicle,stagingEH), [_vehicle]] call CBA_fnc_globalEvent;
+    [QEGVAR(vehicle,radioEH), [_vehicle]] call CBA_fnc_serverEvent;
+    // }, [_vehicle], 1] call CBA_fnc_waitAndExecute;
+}, true, ["man"], true] call CBA_fnc_addClassEventHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- [x] Remove duplicate vehicle inits
- [x] Implement CBA event listeners to call different functions.
- [ ] Ensure events run on correct machines and in correct namespaces.

Note: Execute fn_vehicle_addFunctions with `call`. It is what works as of right now.