### PR TITLE
TFAR Spectator ability to hear others

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -50,7 +50,7 @@ respawnDelay           = 4;
 //respawnDelay           = 30000;               // Enable for 1 life operations and disable the other.
 respawnOnStart         = -1;
 respawnTemplatesWest[] = {"MenuPosition"};
-//respawnTemplates[] = {"ace_spectator"};       // Enable for 1 life operations and disable the other.
+//respawnTemplates[] = {"spectator"};       // Enable for 1 life operations and disable the other.
 
 /*          SYSTEMS           */
 


### PR DESCRIPTION
- Removed ACE_Spectator and put in the vanilla spectator so players can hear alive and talk to other dead players when in the spectator camera.
