### PR TITLE
Ambient enviorment wildlife turned off which gives FPS increase.

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -21,4 +21,6 @@ ACE_maxWeightDrag = 10000;
 
 INFO("init", "Initialization completed.");
 
+enableEnvironment [false, true, 0.5]; // To Turns off or on ambient Wildelife, Ambient Sounds and wind sound strenght.
+
 /* APPLY STUFF ONLY BELOW THIS LINE */

--- a/init.sqf
+++ b/init.sqf
@@ -21,6 +21,6 @@ ACE_maxWeightDrag = 10000;
 
 INFO("init", "Initialization completed.");
 
-enableEnvironment [false, true, 0.5]; // To Turns off or on ambient Wildelife, Ambient Sounds and wind sound strenght.
+enableEnvironment [false, true, 1]; // To Turns off or on ambient Wildelife, Ambient Sounds and wind sound strenght.
 
 /* APPLY STUFF ONLY BELOW THIS LINE */

--- a/init.sqf
+++ b/init.sqf
@@ -16,11 +16,12 @@ if (!isMultiplayer) then {SHOW_CHAT_WARNING("", "Mission is running on singelpla
 
 enableSaving [false, false];
 
+// To Turns off or on ambient Wildelife, Ambient Sounds and wind sound strenght.
+enableEnvironment [false, true, 1];
+
 ACE_maxWeightCarry = 7500;
 ACE_maxWeightDrag = 10000;
 
 INFO("init", "Initialization completed.");
-
-enableEnvironment [false, true, 1]; // To Turns off or on ambient Wildelife, Ambient Sounds and wind sound strenght.
 
 /* APPLY STUFF ONLY BELOW THIS LINE */


### PR DESCRIPTION
- Added in the "enableEnviroment" setting where we can change ambient wildlife, ambient sounds, and wind sound strength.
- Ambient wildlife is turned off and clients see a 5-10+ FPS increase.
