### PR TITLE
Abilities are not reset when applying a lodout array or apply a saved loadout

### DIFF
--- a/cScripts/functions/gear/fn_gear_applyLoadout.sqf
+++ b/cScripts/functions/gear/fn_gear_applyLoadout.sqf
@@ -68,7 +68,9 @@ switch (true) do {
 };
 
 // Abilities
-[_unit, _config] call EFUNC(gear,applyAbilities);
+if (!_loadArray) {
+    [_unit, _config] call EFUNC(gear,applyAbilities);
+};
 
 // Functions
 if (GVAR(isPlayer)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Abilities are not reset when applying a lodout array or apply a saved loadout