### PR TITLE
Improved and made staging check system more reliable and added the ability to have shaped zones

### DIFF
--- a/cScripts/functions/init/fn_init_staging.sqf
+++ b/cScripts/functions/init/fn_init_staging.sqf
@@ -24,14 +24,17 @@ private _stagingZoneMarkers = [];
     private _markerName = [_x, 0, 11] call BIS_fnc_trimString;
     _markerName = toLower _markerName;
     if (_markerName in ["zone_staging", "respawn_west"]) then {
-        _stagingZoneMarkers append [_x];
+        private _type = markerShape _x;
+        private _pos = getMarkerPos _x;
+        _stagingZoneMarkers append [[_x, _type, _pos]];
     };
 } forEach allMapMarkers;
 
 {
-    if (_x in allMapMarkers) then {
-        [_x, 60] call FUNC(addStagingZone);
-    };
+    _x params["_marker", "_type", "_pos"];
+    private _size = if (_type == "ICON") then {60} else {_type};
+    private _zone = if (_type == "ICON") then {_pos} else {_marker};
+    [_zone, _size] call FUNC(addStagingZone);
 } forEach _stagingZoneMarkers;
 
 if !(GVAR(isPlayer)) exitWith {};

--- a/cScripts/functions/init/fn_init_staging.sqf
+++ b/cScripts/functions/init/fn_init_staging.sqf
@@ -19,70 +19,20 @@ if !(EGVAR(Settings,enableStagingSystem)) exitWith {};
 
 INFO("Staging", "Setting up Staging");
 
-private _respawnMarkers = [
-    "respawn_west",
-    "respawn_west_0",
-    "respawn_west_1",
-    "respawn_west_2",
-    "respawn_west_3",
-    "respawn_west_4",
-    "respawn_west_5",
-    "respawn_west_6",
-    "respawn_west_7",
-    "respawn_west_8",
-    "respawn_west_9",
-    "respawn_west_10",
-    "respawn_west_11",
-    "respawn_west_12",
-    "respawn_west_13",
-    "respawn_west_14",
-    "respawn_west_15",
-    "respawn_west_16",
-    "respawn_west_17",
-    "respawn_west_18",
-    "respawn_west_19",
-    "respawn_west_20"
-];
-private _stagingMarkers = [
-    "zone_staging",
-    "zone_staging_0",
-    "zone_staging_1",
-    "zone_staging_2",
-    "zone_staging_3",
-    "zone_staging_4",
-    "zone_staging_5",
-    "zone_staging_6",
-    "zone_staging_7",
-    "zone_staging_8",
-    "zone_staging_9",
-    "zone_staging_10",
-    "zone_staging_11",
-    "zone_staging_12",
-    "zone_staging_13",
-    "zone_staging_14",
-    "zone_staging_15",
-    "zone_staging_16",
-    "zone_staging_17",
-    "zone_staging_18",
-    "zone_staging_19",
-    "zone_staging_20",
-    "zone_staging_21",
-    "zone_staging_22",
-    "zone_staging_23",
-    "zone_staging_24",
-    "zone_staging_25",
-    "zone_staging_26",
-    "zone_staging_27",
-    "zone_staging_28",
-    "zone_staging_29",
-    "zone_staging_30"
-];
+private _stagingZoneMarkers = [];
+{
+    private _markerName = [_x, 0, 11] call BIS_fnc_trimString;
+    _markerName = toLower _markerName;
+    if (_markerName in ["zone_staging", "respawn_west"]) then {
+        _stagingZoneMarkers append [_x];
+    };
+} forEach allMapMarkers;
 
 {
     if (_x in allMapMarkers) then {
         [_x, 60] call FUNC(addStagingZone);
     };
-} forEach _respawnMarkers + _stagingMarkers;
+} forEach _stagingZoneMarkers;
 
 if !(GVAR(isPlayer)) exitWith {};
 

--- a/cScripts/functions/mission/fn_addStagingZone.sqf
+++ b/cScripts/functions/mission/fn_addStagingZone.sqf
@@ -1,47 +1,81 @@
 #include "..\script_component.hpp";
 /*
  * Author: CPL.Brostrom.A
- * This function adds a given object or marker to the missionNamespace listing staging zones.
+ * This function creates a staging zone and saves it to a mission name space.
+ * The zone can be OBJECT, MARKER or POSITION ARRAY
  *
  * Arguments:
- * 0: Zone <OBJECT/STRING>
- * 1: Zone Size <NUMBER> (Optional) [Default; 12]
+ * 0: Zone <OBJECT/STRING/ARRAY>
+ * 1: Zone Size <NUMBER/STRING> (Optional) [Default; 12]
  *
  * Return:
  * Nothing
  *
  * Example:
  * [this] call cScripts_fnc_addStagingZone
- * [bob, 2] call cScripts_fnc_addStagingZone
- * [TruckMcTruckFace, 12] call cScripts_fnc_addStagingZone
+ * [this, 3] call cScripts_fnc_addStagingZone
+ * ["zone_staging", 12] call cScripts_fnc_addStagingZone
  * ["respawn_west", 12] call cScripts_fnc_addStagingZone
+ * [[10,25,0], 12] call cScripts_fnc_addStagingZone
+ * ["ShapedZoneMarker", "RECTANGLE"] call cScripts_fnc_addStagingZone
+ * ["ShapedZoneMarker", "ELLIPSE"] call cScripts_fnc_addStagingZone
+ * 
+ * Public: Yes
  */
 
 params [
-    ["_zone", objNull, [objNull, ""]],
-    ["_size", 12, [0]]
+    ["_zone", objNull, [objNull, "", []]],
+    ["_size", 12, [0, ""]]
 ];
 
 private _stagingZones = GETMVAR(EGVAR(Staging,Zones), []);
 
-// Check if zone is marker
-if (_zone isEqualType "") then {
-    private _markerPos = getMarkerPos _zone;
-    _zone = "UserTexture1m_F" createVehicle _markerPos;
+// Position or Icon zone
+if (_zone isEqualType []) exitWith {
+    INFO("Staging", "Creating postion type staging zone (Icon marker or Set position)");
+    private _zoneSize = if (_size isEqualType 0) then {[_size, _size]} else {SHOW_CHAT_WARNING("Staging", "Zone size <STRING> not valid for position type zones. Setting zone size to 12");[12, 12]};
+    private _zonePos = _zone;
+    private _zoneType = [];
+
+    private _stagingZone = createMarkerLocal [format["cScripts_staging_zone_%1", count _stagingZones], _zonePos];
+    _stagingZone setMarkerShapeLocal "ELLIPSE";
+    _stagingZone setMarkerSizeLocal _zoneSize;
+    _stagingZone setMarkerBrushLocal "Border";
+    _stagingZone setMarkerColorLocal "ColorOrange";
+
+    _stagingZones append [[_stagingZone, _zoneSize, _zoneType]];
+    SETMVAR(EGVAR(Staging,Zones), _stagingZones);
 };
 
-_stagingZones pushBack [_zone, _size];
+// Shape marker zone
+if (_zone isEqualType "") exitWith {
+    INFO("Staging", "Creating shape marker type staging zone");
+    private _zoneSize = if (_size isEqualType 0) then {[_size, _size]} else {getMarkerSize _zone};
+    private _zoneShape = _size;
+    private _zonePos = markerPos _zone;
+    private _zoneDir = markerDir _zone;
+    private _zoneType = "";
 
-SETMVAR(EGVAR(Staging,Zones), _stagingZones);
+    private _stagingZone = createMarkerLocal [format["cScripts_staging_zone_%1", count _stagingZones], _zonePos];
+    _stagingZone setMarkerShapeLocal _zoneShape;
+    _stagingZone setMarkerSizeLocal _zoneSize;
+    _stagingZone setMarkerDirLocal _zoneDir;
+    _stagingZone setMarkerBrushLocal "Border";
+    _stagingZone setMarkerColorLocal "ColorOrange";
 
-INFO_2("Staging", "Staging zone %1 (%2) created.", count _stagingZones, _zone);
+    _stagingZones append [[_stagingZone, _zoneSize, _zoneType]];
+    SETMVAR(EGVAR(Staging,Zones), _stagingZones);
+};
 
-// Vehicles dont paint out the zone
-if (_zone isKindOf "AllVehicles") exitWith {};
-INFO_2("Staging", "Revlealing staging zone %1 (%2)", count _stagingZones, _zone);
+// Object type zone
+if (_zone isEqualType objNull) exitWith {
+    INFO("Staging", "Creating vehicle type staging zone");
+    private _zoneSize = if (_size isEqualType 0) then {[_size, _size]} else {SHOW_CHAT_WARNING("Staging", "Zone size <STRING> not valid for position type zones. Setting zone size to 12");[12, 12]};
+    private _zoneType = objNull;
+    private _stagingZone = _zone;
 
-private _visibleZone = createMarkerLocal [format["VisibleStadgeingMarker_%1", count _stagingZones], _zone];
-_visibleZone setMarkerShapeLocal "ELLIPSE";
-_visibleZone setMarkerSizeLocal [_size, _size];
-_visibleZone setMarkerBrushLocal "Border";
-_visibleZone setMarkerColorLocal "ColorYellow";
+    _stagingZones append [[_stagingZone, _zoneSize, _zoneType]];
+    SETMVAR(EGVAR(Staging,Zones), _stagingZones);
+};
+
+if (isNil{_stagingZone}) exitWith {ERROR_1("Staging", "Staging zone %1 not created.", _zone);};

--- a/cScripts/functions/mission/fn_doStarterCrate.sqf
+++ b/cScripts/functions/mission/fn_doStarterCrate.sqf
@@ -92,7 +92,7 @@ _object enableRopeAttach false;
 
 // Stageing zone
 if (_hasStagingZone) then {
-    [_object, 25] call FUNC(addStagingZone);
+    [getPos _object, 25] call FUNC(addStagingZone);
 };
 
 // Add save gear eventHandler

--- a/cScripts/functions/systems/fn_checkStagingZone.sqf
+++ b/cScripts/functions/systems/fn_checkStagingZone.sqf
@@ -14,27 +14,24 @@
  */
 
 false;
-private _stagingZones        = missionNamespace getVariable [QEGVAR(Staging,Zones), []];
-private _stagingZonesEnabled = missionNamespace getVariable [QEGVAR(mission,stagingZonesEnabled), true];
+private _stagingZones        = GETMVAR(EGVAR(Staging,Zones), []);
+private _stagingZonesEnabled = GETMVAR(EGVAR(Mission,stagingZonesEnabled), true);
 
 if !(_stagingZonesEnabled) exitWith { false };
 if (EGVAR(Staging,ZoneStatus)) exitWith { true };
 
 if (count _stagingZones > 0) then {
     {
-        _x params ["_zone", "_maxDistance"];
-        private _zonePos = [0,0,0];
-        if (_zone isEqualType objNull) then {
-            _zone = _zone call BIS_fnc_netId;
-            _zone = _zone call BIS_fnc_objectFromNetId;
-            _zonePos = getPos _zone;
-        };
-        if (_zone isEqualType "") then {
-            _zonePos = getMarkerPos _zone;
-        };
-        private _distance = player distance _zonePos;
+        _x params ["_zone", "_size", "_type"];
 
-        if (_distance <= _maxDistance) exitWith { true };
-        false;
+        private _playerHight = (getPosVisual player)#2;
+        if (player inArea _zone && _playerHight <= 30 ) exitWith { true };
+
+        // Object distacne check
+        private _objectZoneSize = _size#0;
+        private _distance = if (_type isEqualType objNull) then {player distance getPos _zone} else {999999};
+        private _checkDistance = if (_type isEqualType objNull) then {_distance <= _objectZoneSize} else {false};
+        if (_checkDistance) exitWith { true };
+        false
     } forEach _stagingZones;
 } else { false };


### PR DESCRIPTION
**When merged this pull request will:**
- Changed marker checks with a simple "whildcard" check instead of activly looking for exact names.
  We now accept `zone_staging` and `respawn_west` as well as crazyer names like: `zone_staging_MyZoneHere_123545`
- Zones are now able to be on any kind of marker or object.  Naming a shaped marker zone `zone_staging` will make the staging zone as the shape of the marker.
- Icons will have the same behaviour.
- Startcrate now create a positional zone instead of a object zone.


## TODO
- [x] Make inArea checks instead of distance allowing rectangle zone making.