### PR TITLE
Changed starter crate now uses object postion again

### DIFF
--- a/cScripts/functions/mission/fn_doStarterCrate.sqf
+++ b/cScripts/functions/mission/fn_doStarterCrate.sqf
@@ -92,7 +92,7 @@ _object enableRopeAttach false;
 
 // Stageing zone
 if (_hasStagingZone) then {
-    [getPos _object, 25] call FUNC(addStagingZone);
+    [_object, 25] call FUNC(addStagingZone);
 };
 
 // Add save gear eventHandler


### PR DESCRIPTION
**When merged this pull request will:**
- Changed starter crate now uses object postion again (Reverted change from #1075)