### PR TITLE
Fixed typo for civilian zone marker names

### DIFF
--- a/cScripts/functions/civ/fn_civ_init.sqf
+++ b/cScripts/functions/civ/fn_civ_init.sqf
@@ -22,7 +22,7 @@ private _civZones = [];
 {
     private _markerName = [_x, 0, 21] call BIS_fnc_trimString;
     _markerName = toLower _markerName;
-    if (_markerName == "cscripts_civilan_zone_") then {
+    if (_markerName == "cscripts_civilian_zone_") then {
         private _density = [_x, 21] call BIS_fnc_trimString;
         _density = (_density splitString "_")#0;
         if !(_density in ["extream", "high", "medium", "low", "none"]) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Fixed typo for civilian zone marker names