### PR TITLE
Changed player arsenal whitelist to be created on loadout application instead of each time arsenal is opened

### DIFF
--- a/cScripts/functions/gear/fn_gear_applyLoadout.sqf
+++ b/cScripts/functions/gear/fn_gear_applyLoadout.sqf
@@ -89,6 +89,9 @@ _unit selectWeapon (primaryWeapon _unit);
 // Lower the weapon
 if !(weaponLowered _unit) then {_unit action ["WeaponOnBack", _unit]};
 
+if (GVAR(isPlayer)) then {
+    [QEGVAR(StagingArsenal,SaveWhitelist)] call CBA_fnc_localEvent;
+};
 
 if (_loadConfig) then {
     INFO_2("Gear", "Applying postLoadout code for %1 [%2]", _unit, typeOf _unit);

--- a/cScripts/functions/init/fn_init_aceArsenal.sqf
+++ b/cScripts/functions/init/fn_init_aceArsenal.sqf
@@ -37,3 +37,10 @@ GVAR(StagingArsenalOpen) = false;
 [QEGVAR(StagingArsenal,displayOpen), {
     GVAR(StagingArsenalOpen) = true;
 }] call CBA_fnc_addEventHandler;
+
+[QEGVAR(StagingArsenal,SaveWhitelist), {
+    private _items = call FUNC(getArsenalWhitelist);
+    SETVAR(player,EGVAR(Player,ArsenalWhitelist), _items);
+}] call CBA_fnc_addEventHandler;
+
+

--- a/cScripts/functions/systems/fn_addArsenal.sqf
+++ b/cScripts/functions/systems/fn_addArsenal.sqf
@@ -24,7 +24,7 @@ private _arsenalStatement = {
     call FUNC(addDefaultArsenalLoadout);
     waitUntil { count ace_arsenal_defaultLoadoutsList != 0 };
 
-    private _items = call FUNC(getArsenalWhitelist);
+    private _items = GETVAR(player,EGVAR(Player,ArsenalWhitelist), []);
     INFO_3("Staging Arsenal", "Whitleist containing %1 items added to %2 (%3)", count _items, player, typeOf player);
     if (count _items == 0) exitWith {
         [


### PR DESCRIPTION
**When merged this pull request will:**
- Changed arsenal whitelist being created on player each time you select laodout instead of each time you open arsenal.
- Added EventHandler to save arsenal whitelist on on local player

Possible Closes #1136 