### PR TITLE
Fixed missing quotes in HMMWV inventory getter

### DIFF
--- a/cScripts/functions/systems/fn_getArsenalWhitelist.sqf
+++ b/cScripts/functions/systems/fn_getArsenalWhitelist.sqf
@@ -25,32 +25,32 @@ _unitItems = parseSimpleArray ("[" + _unitItems + "]");
 _unitItems = _unitItems arrayIntersect _unitItems select {_x isEqualType "" && {_x != ""}};
 
 
-private _commonGear = GET_CONTAINER_KEYS(arsenal_common);
+private _commonGear = GET_CONTAINER_KEYS("arsenal_common");
 
 
 private _company = call EFUNC(player,getCompany);
 private _companyItems = switch (_company) do {
-    case "alpha": {GET_CONTAINER_KEYS(alpha_company);};
-    case "bravo": {GET_CONTAINER_KEYS(bravo_company);};
-    case "charlie": {GET_CONTAINER_KEYS(charlie_company);};
-    default {GET_CONTAINER_KEYS(arsenal_company_fallback);};
+    case "alpha": {GET_CONTAINER_KEYS("alpha_company");};
+    case "bravo": {GET_CONTAINER_KEYS("bravo_company");};
+    case "charlie": {GET_CONTAINER_KEYS("charlie_company");};
+    default {GET_CONTAINER_KEYS("arsenal_company_fallback");};
 };
 
 
 private _medicRole = getNumber (missionConfigFile >> "CfgLoadouts" >> _classname >> "abilityMedic");
-private _medicGear = if (_medicRole >= 1) then {GET_CONTAINER_KEYS(bravo_company_atlas);} else {[]};
+private _medicGear = if (_medicRole >= 1) then {GET_CONTAINER_KEYS("bravo_company_atlas");} else {[]};
 
 
 private _roleSpecific = switch ([player] call EFUNC(gear,getLoadoutRole)) do {
-    case "officer": {GET_CONTAINER_KEYS(arsenal_role_officer);};
-    case "squadleader": {GET_CONTAINER_KEYS(arsenal_role_squadleader);};
-    case "fireteamleader": {GET_CONTAINER_KEYS(arsenal_role_fireteamleader);};
-    case "weapons": {GET_CONTAINER_KEYS(arsenal_role_weapons);};
+    case "officer": {GET_CONTAINER_KEYS("arsenal_role_officer");};
+    case "squadleader": {GET_CONTAINER_KEYS("arsenal_role_squadleader");};
+    case "fireteamleader": {GET_CONTAINER_KEYS("arsenal_role_fireteamleader");};
+    case "weapons": {GET_CONTAINER_KEYS("arsenal_role_weapons");};
     case "pilot";
-    case "rotarypilot": {GET_CONTAINER_KEYS(arsenal_role_rotarypilot);};
-    case "rotarycrew": {GET_CONTAINER_KEYS(arsenal_role_pilotcrew);};
-    case "pilotfighter": {GET_CONTAINER_KEYS(arsenal_role_pilotfighter);};
-    case "pilottransport": {GET_CONTAINER_KEYS(arsenal_role_pilottransport);};
+    case "rotarypilot": {GET_CONTAINER_KEYS("arsenal_role_rotarypilot");};
+    case "rotarycrew": {GET_CONTAINER_KEYS("arsenal_role_pilotcrew");};
+    case "pilotfighter": {GET_CONTAINER_KEYS("arsenal_role_pilotfighter");};
+    case "pilottransport": {GET_CONTAINER_KEYS("arsenal_role_pilottransport");};
     default {[]};
 };
 
@@ -58,18 +58,18 @@ private _roleSpecific = switch ([player] call EFUNC(gear,getLoadoutRole)) do {
 private _primaryWeapon = if (!isNil{_loadout#0#0}) then {_loadout#0#0} else {""};
 private _weaponSystemSpecific = switch (true) do {
     case (_primaryWeapon isKindof ['rhs_weap_mk18_m320', configFile >> 'CfgWeapons']
-            || _primaryWeapon isKindof ['rhs_weap_m16a4_carryhandle_M203', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS(arsenal_weap_ugl);};
+            || _primaryWeapon isKindof ['rhs_weap_m16a4_carryhandle_M203', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS("arsenal_weap_ugl");};
 
     case (_primaryWeapon isKindof ['rhs_weap_m4a1', configFile >> 'CfgWeapons']
-            || _primaryWeapon isKindof ['rhs_weap_m16a4', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS(arsenal_weap_m4);};
+            || _primaryWeapon isKindof ['rhs_weap_m16a4', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS("arsenal_weap_m4");};
 
-    case (_primaryWeapon isKindof ['rhs_weap_sr25_ec', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS(arsenal_weap_sr25);};
+    case (_primaryWeapon isKindof ['rhs_weap_sr25_ec', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS("arsenal_weap_sr25");};
 
-    case (primaryWeapon player isKindof ['rhs_weap_m240_base', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS(arsenal_weap_m240);};
+    case (primaryWeapon player isKindof ['rhs_weap_m240_base', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS("arsenal_weap_m240");};
 
     case (primaryWeapon player isKindof ['rhs_weap_m249_pip', configFile >> 'CfgWeapons']
             || _primaryWeapon isKindof ['rhs_weap_m249_pip_L', configFile >> 'CfgWeapons']
-            || _primaryWeapon isKindof ['rhs_weap_m249_pip_S', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS(arsenal_weap_m249);};
+            || _primaryWeapon isKindof ['rhs_weap_m249_pip_S', configFile >> 'CfgWeapons']): {GET_CONTAINER_KEYS("arsenal_weap_m249");};
 
     default {[]};
 };

--- a/cScripts/functions/vehicle/fn_vehicle_addInventory.sqf
+++ b/cScripts/functions/vehicle/fn_vehicle_addInventory.sqf
@@ -194,7 +194,7 @@ if (_vehicle iskindOf "MRAP_01_base_F") then {
         case "rhsusf_m1165a1_gmv_mk19_m240_socom_d";
         case "rhsusf_m1165a1_gmv_mk19_m240_socom_w": {
             [_vehicle, 
-                GET_CONTAINER(vehicle_HMMWV_Weapons)
+                GET_CONTAINER("vehicle_HMMWV_Weapons")
             ] call FUNC(addCargo);
         };
         default {


### PR DESCRIPTION
**When merged this pull request will:**
- Fix missing quotes in GET_CONTAINER parameter for HMMWV weapons inventory.
- Fix all missing quotes in all calls of GET_CONTAINER_KEYS.
- Respect the [Development Guidelines](https://github.com/7Cav/cScripts/wiki/Code-and-development-policy)
