### PR TITLE
Added DMR Ammo and rebalanced mortar ammo

### DIFF
--- a/cScripts/functions/init/fn_init_logistics.sqf
+++ b/cScripts/functions/init/fn_init_logistics.sqf
@@ -756,6 +756,7 @@ private _dataArray = [
     ["crate_resupply_general", [
         // Rifle Ammo
         ["rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",70],
+        ["rhsusf_20Rnd_762x51_SR25_m118_special_Mag",5],
         
         // MG Ammo
         ["rhsusf_200rnd_556x45_mixed_soft_pouch",15],
@@ -763,7 +764,7 @@ private _dataArray = [
 
         // AT
         ["rhs_fgm148_magazine_AT",3],
-        ["MRAWS_HEAT_F",4],
+        ["MRAWS_HEAT_F",5],
         ["MRAWS_HE_F",4],
         ["rhs_weap_M136_hedp",8],
         
@@ -778,10 +779,10 @@ private _dataArray = [
         ["ACE_40mm_Flare_IR",10],
 
         // Mortar Ammo
-        ["NDS_M_6Rnd_60mm_HE_0",5],
-        ["NDS_M_6Rnd_60mm_HE",5],
+        ["NDS_M_6Rnd_60mm_HE_0",3],
+        ["NDS_M_6Rnd_60mm_HE",7],
         ["NDS_M_6Rnd_60mm_SMOKE",2],
-        ["NDS_M_6Rnd_60mm_ILLUM",2],
+        ["NDS_M_6Rnd_60mm_ILLUM",1],
         
         // Offensive/Defensive Hand Grenades
         ["HandGrenade",20],

--- a/cScripts/functions/init/fn_init_logistics.sqf
+++ b/cScripts/functions/init/fn_init_logistics.sqf
@@ -756,16 +756,16 @@ private _dataArray = [
     ["crate_resupply_general", [
         // Rifle Ammo
         ["rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",70],
-        ["rhsusf_20Rnd_762x51_SR25_m118_special_Mag",5],
+        ["rhsusf_20Rnd_762x51_SR25_m118_special_Mag",7],
         
         // MG Ammo
-        ["rhsusf_200rnd_556x45_mixed_soft_pouch",15],
+        ["rhsusf_200rnd_556x45_mixed_soft_pouch",19],
         ["rhsusf_100Rnd_762x51_m62_tracer",15],
 
         // AT
         ["rhs_fgm148_magazine_AT",3],
-        ["MRAWS_HEAT_F",5],
-        ["MRAWS_HE_F",4],
+        ["MRAWS_HEAT_F",6],
+        ["MRAWS_HE_F",3],
         ["rhs_weap_M136_hedp",8],
         
         // AA
@@ -782,7 +782,6 @@ private _dataArray = [
         ["NDS_M_6Rnd_60mm_HE_0",3],
         ["NDS_M_6Rnd_60mm_HE",7],
         ["NDS_M_6Rnd_60mm_SMOKE",2],
-        ["NDS_M_6Rnd_60mm_ILLUM",1],
         
         // Offensive/Defensive Hand Grenades
         ["HandGrenade",20],

--- a/cScripts/functions/init/fn_init_logistics.sqf
+++ b/cScripts/functions/init/fn_init_logistics.sqf
@@ -759,8 +759,8 @@ private _dataArray = [
         ["rhsusf_20Rnd_762x51_SR25_m118_special_Mag",7],
         
         // MG Ammo
-        ["rhsusf_200rnd_556x45_mixed_soft_pouch",19],
-        ["rhsusf_100Rnd_762x51_m62_tracer",15],
+        ["rhsusf_200rnd_556x45_mixed_soft_pouch",16],
+        ["rhsusf_100Rnd_762x51_m62_tracer",19],
 
         // AT
         ["rhs_fgm148_magazine_AT",3],


### PR DESCRIPTION
Added:
- 5 magazines for DMR so we can re-supply them in the field.

Shifted Mortar ammo and MAAWS ammo toward the ammo we use during OP. The crate inventory size is not exceeded.