### PR TITLE
Removed "medicGear" from whitelist variables again

### DIFF
--- a/cScripts/functions/systems/fn_getArsenalWhitelist.sqf
+++ b/cScripts/functions/systems/fn_getArsenalWhitelist.sqf
@@ -97,6 +97,6 @@ private _launcherSpecific = switch (true) do {
     default {[]};
 };
 
-private _whitelist = _commonGear + _unitItems + _companyItems + _roleSpecific + _medicGear + _primarySpecific + _handgunSpecific + _launcherSpecific;
+private _whitelist = _commonGear + _unitItems + _companyItems + _roleSpecific + _primarySpecific + _handgunSpecific + _launcherSpecific;
 
 _whitelist


### PR DESCRIPTION
**When merged this pull request will:**
- Remove "medicGear" from whitelist variables to avoid script error.
- Respect the [Development Guidelines](https://github.com/7Cav/cScripts/wiki/Code-and-development-policy)
