### PR TITLE
Fixed TFAR radio duplication bug

### DIFF
--- a/cScripts/cScripts_preInit.sqf
+++ b/cScripts/cScripts_preInit.sqf
@@ -16,6 +16,7 @@ EGVAR(patches,usesACRE)         = isClass (configFile >> "CfgPatches" >> "acre_s
 EGVAR(patches,usesTFAR)         = isClass (configFile >> "CfgPatches" >> "task_force_radio");
 EGVAR(patches,usesAlive)        = isClass (configFile >> "CfgPatches" >> "ALiVE_main");
 EGVAR(patches,usesZen)          = isClass (configFile >> "CfgPatches" >> "zen_main");
+EGVAR(patches,usesACEAX)        = isCLass (configFile >> "CfgPatches" >> "aceax_main");
 
 // Global Variables
 EGVAR(Staging,ZoneStatus) = false;

--- a/cScripts/functions/gear/fn_gear_saveLoadout.sqf
+++ b/cScripts/functions/gear/fn_gear_saveLoadout.sqf
@@ -16,9 +16,8 @@
 
 params [["_unit", objNull, [objNull]]];
 
-private _loadout = getUnitLoadout _unit;
-if (EGVAR(patches,usesACRE)) then { _loadout = [_loadout] call acre_api_fnc_filterUnitLoadout; };
-_loadout = [_unit] call CBA_fnc_getLoadout;
+private _loadout = [_unit] call CBA_fnc_getLoadout;
+_loadout = [_loadout] call FUNC(filterUnitLoadout);
 
 _unit setVariable [QEGVAR(Gear,Loadout), _loadout];
 _unit setVariable [QEGVAR(Gear,SavedLoadout), true];

--- a/cScripts/functions/systems/fn_filterUnitLoadout.sqf
+++ b/cScripts/functions/systems/fn_filterUnitLoadout.sqf
@@ -20,22 +20,27 @@
 params [["_loadout", getUnitLoadout player, [[], objNull, "", configNull]]];
 
 if !(_loadout isEqualType []) then {
-    _loadout = getUnitLoadout _loadout;
+    _loadout = [_loadout] call CBA_fnc_getLoadout;
 };
 
 if (_loadout isEqualTo []) exitWith {
-    _loadout
+    _loadout;
+};
+
+private _baseLoadout = _loadout;
+if (EGVAR(Patches,usesACEAX)) then {
+    _baseLoadout = _loadout#0;
 };
 
 // Remove "ItemRadioAcreFlagged"
-if ((_loadout select 9) select 2 == "ItemRadioAcreFlagged") then {
-    (_loadout select 9) set [2, ""];
+if (_baseLoadout#9#2 == "ItemRadioAcreFlagged") then {
+    _baseLoadout#9 set [2, ""];
 };
 
 // Set ACRE base classes
 private _replaceRadio = {
     params ["_item"];
-    if (EGVAR(Patches,usesACRE)) then {
+        if (EGVAR(Patches,usesACRE)) then {
         // Replace only if string (array can be eg. weapon inside container) and an ACRE radio
         if (!(_item isEqualType []) && {[_item] call acre_api_fnc_isRadio}) then {
             _this set [0, [_item] call acre_api_fnc_getBaseRadio];
@@ -43,21 +48,27 @@ private _replaceRadio = {
     };
     if (EGVAR(Patches,usesTFAR)) then {
         // Replace only if string (array can be eg. weapon inside container) and an TFAR radio
-        if (!(_item isEqualType []) && {[_item] call TFAR_fnc_isRadio}) then {
+        if (!(_item isEqualType []) && {_item call TFAR_fnc_isRadio}) then {
             private _baseClassRadio = getText (configFile >> "CfgWeapons" >> _item >> "ace_arsenal_uniqueBase");
             _this set [0, _baseClassRadio];
         };
     };
 };
-if ((_loadout select 3) isNotEqualTo []) then {
-    {_x call _replaceRadio} forEach ((_loadout select 3) select 1); // Uniform items
-};
-if ((_loadout select 4) isNotEqualTo []) then {
-    {_x call _replaceRadio} forEach ((_loadout select 4) select 1); // Vest items
-};
-if ((_loadout select 5) isNotEqualTo []) then {
-    {_x call _replaceRadio} forEach ((_loadout select 5) select 1); // Backpack items
+
+if ((_baseLoadout#3) isNotEqualTo []) then {
+    {_x call _replaceRadio} forEach (_baseLoadout#3#1); // Uniform items
 };
 
+if ((_baseLoadout#4) isNotEqualTo []) then {
+    {_x call _replaceRadio} forEach (_baseLoadout#4#1); // Vest items
+};
+
+if ((_baseLoadout#5) isNotEqualTo []) then {
+    {_x call _replaceRadio} forEach (_baseLoadout#5#1); // Backpack items
+};
+
+if (EGVAR(Patches,usesACEAX)) then {
+    _loadout set [0,_baseLoadout];
+};
 
 _loadout


### PR DESCRIPTION
**When merged this pull request will:**
- Fix a bug that causes duplicate radio ids to spawn with TFAR.
- Actually implement `fn_filterUnitLoadout`.
- Respect the [Development Guidelines](https://github.com/7Cav/cScripts/wiki/Code-and-development-policy)
