### PR TITLE
Fixed missing genadiers in Viking Compositions

### DIFF
--- a/Compositions/1.Cav_Viking_Platoon/composition.sqe
+++ b/Compositions/1.Cav_Viking_Platoon/composition.sqe
@@ -1,5 +1,5 @@
 version=54;
-center[]={1172.4204,5,6143.8301};
+center[]={4631.9644,5,3775.3059};
 class items
 {
 	items=7;
@@ -22,7 +22,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-2.9891357,0.0014390945,14.947754};
+							position[]={-2.9892578,0.0014390945,14.943359};
 							angles[]={0,3.1415927,0};
 						};
 						side="West";
@@ -35,7 +35,7 @@ class items
 							description="Platoon Leader@VIKING-6";
 							isPlayable=1;
 						};
-						id=2;
+						id=1167;
 						type="Cav_B_B_Scout_PlatoonLead_2_6_F";
 						class CustomAttributes
 						{
@@ -73,14 +73,14 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=1;
+				id=1166;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-0.2467041,0.89242268,12.520996};
+					position[]={-0.24658203,0.89242268,12.516602};
 					angles[]={-0,1.5526583,0};
 				};
 				side="Empty";
@@ -90,7 +90,7 @@ class items
 					init="call{[this,""Bravo"",true,true,true,false,false] call cScripts_fnc_doStarterCrate;}";
 					dynamicSimulation=1;
 				};
-				id=3;
+				id=1168;
 				type="B_supplyCrate_F";
 				class CustomAttributes
 				{
@@ -141,7 +141,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={14.30603,0.89242268,2.215332};
+					position[]={14.306152,0.89242268,2.2109375};
 				};
 				side="Empty";
 				flags=4;
@@ -150,7 +150,7 @@ class items
 					init="call{[this,""Bravo"",true,true,true,false,false] call cScripts_fnc_doStarterCrate;}";
 					dynamicSimulation=1;
 				};
-				id=4;
+				id=1169;
 				type="B_supplyCrate_F";
 				class CustomAttributes
 				{
@@ -201,18 +201,18 @@ class items
 				dataType="Comment";
 				class PositionInfo
 				{
-					position[]={1.7425537,0,7.0395508};
+					position[]={1.7426758,0,7.0351563};
 				};
 				title="Stryker Scout Platoon (Tooltip)";
 				description="B/1-7's Stryker Scout Platoon is a hybrid fighting force that specializes in scout tasks and missions. They handle everything from Screening Operations, Guard Operations, Ambushes, Area Reconnaissance, and all other general infantry tasks. While the composition utilizes 6 Strykers for the Platoon, unless it's completely full, they'll mostly only use 4 or 5. Viking does NOT require a JTAC to call in CAS as they are trained and capable of doing so internally.";
-				id=5;
+				id=1170;
 			};
 			class Item4
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.5269775,2.6142888,19.305176};
+					position[]={-6.5268555,2.6142888,19.300781};
 				};
 				side="Empty";
 				flags=4;
@@ -220,7 +220,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=6;
+				id=1171;
 				type="cav_dragoon_WD_V6";
 				class CustomAttributes
 				{
@@ -259,7 +259,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-2.9891357,0.0014390945,16.447754};
+									position[]={-2.9892578,0.0014390945,16.443359};
 									angles[]={0,3.1415927,0};
 								};
 								side="West";
@@ -271,7 +271,7 @@ class items
 									description="Stryker Vehicle Commander@SIERRA-6";
 									isPlayable=1;
 								};
-								id=9;
+								id=1174;
 								type="Cav_B_B_Ifv_Commander_F";
 								class CustomAttributes
 								{
@@ -322,7 +322,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-2.9891357,0.0014390945,17.947754};
+									position[]={-2.9892578,0.0014390945,17.943359};
 									angles[]={0,3.1415927,0};
 								};
 								side="West";
@@ -334,7 +334,7 @@ class items
 									description="Stryker Driver@SIERRA-6";
 									isPlayable=1;
 								};
-								id=10;
+								id=1175;
 								type="Cav_B_B_Ifv_Driver_F";
 								class CustomAttributes
 								{
@@ -384,13 +384,13 @@ class items
 						class Attributes
 						{
 						};
-						id=8;
+						id=1173;
 					};
 				};
-				id=7;
+				id=1172;
 			};
 		};
-		id=0;
+		id=1165;
 	};
 	class Item1
 	{
@@ -411,7 +411,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.4403076,0.0014390945,15.67041};
+							position[]={2.4404297,0.0014390945,15.666016};
 							angles[]={0,3.1415927,0};
 						};
 						side="West";
@@ -424,7 +424,7 @@ class items
 							description="Platoon Sergeant@VIKING-5";
 							isPlayable=1;
 						};
-						id=13;
+						id=1178;
 						type="Cav_B_B_Scout_PlatoonLead_2_5_F";
 						class CustomAttributes
 						{
@@ -462,7 +462,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.4405518,0.0014390945,17.17041};
+							position[]={2.4404297,0.0014390945,17.166016};
 							angles[]={0,3.1415927,0};
 						};
 						side="West";
@@ -474,7 +474,7 @@ class items
 							description="Stryker Driver";
 							isPlayable=1;
 						};
-						id=14;
+						id=1179;
 						type="Cav_B_B_Ifv_Driver_F";
 						class CustomAttributes
 						{
@@ -525,14 +525,14 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=12;
+				id=1177;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.2366943,2.6142888,19.23877};
+					position[]={6.2368164,2.6142888,19.234375};
 					angles[]={-0,0.005982683,0};
 				};
 				side="Empty";
@@ -541,7 +541,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=15;
+				id=1180;
 				type="cav_dragoon_WD_V5";
 				class CustomAttributes
 				{
@@ -562,7 +562,7 @@ class items
 				};
 			};
 		};
-		id=11;
+		id=1176;
 	};
 	class Item2
 	{
@@ -583,7 +583,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={1.6568604,0.0014390945,15.876953};
+							position[]={1.6567383,0.0014390945,15.872559};
 							angles[]={0,3.1415927,0};
 						};
 						side="West";
@@ -596,7 +596,7 @@ class items
 							description="Platoon Medic@VIKING-7";
 							isPlayable=1;
 						};
-						id=18;
+						id=1183;
 						type="Cav_B_B_Scout_PlatoonMedic_2_7_F";
 						class CustomAttributes
 						{
@@ -647,10 +647,10 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=17;
+				id=1182;
 			};
 		};
-		id=16;
+		id=1181;
 	};
 	class Item3
 	{
@@ -671,7 +671,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-11.740112,0.0014390945,-0.31591797};
+							position[]={-11.740234,0.0014390945,-0.3203125};
 						};
 						side="West";
 						flags=6;
@@ -682,7 +682,7 @@ class items
 							description="Squad Leader@VIKING-1";
 							isPlayable=1;
 						};
-						id=21;
+						id=1186;
 						type="Cav_B_B_Scout_SquadLeader_F";
 						class CustomAttributes
 						{
@@ -720,7 +720,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-13.739868,0.0014390945,-1.315918};
+							position[]={-13.739746,0.0014390945,-1.3203125};
 						};
 						side="West";
 						flags=5;
@@ -732,7 +732,7 @@ class items
 							description="Alpha Team Leader";
 							isPlayable=1;
 						};
-						id=22;
+						id=1187;
 						type="Cav_B_B_Scout_Alpha_TeamLead_F";
 						class CustomAttributes
 						{
@@ -770,7 +770,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-13.739868,0.0014390945,-2.815918};
+							position[]={-13.739746,0.0014390945,-2.8203125};
 						};
 						side="West";
 						flags=5;
@@ -781,7 +781,7 @@ class items
 							description="Alpha Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=23;
+						id=1188;
 						type="Cav_B_B_Scout_Alpha_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -819,56 +819,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-13.739868,0.0014390945,-4.315918};
-						};
-						side="West";
-						flags=4;
-						class Attributes
-						{
-							skill=0.40000001;
-							init="this setGroupid [""VIKING-1""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-1""];";
-							description="Alpha Grenadier";
-							isPlayable=1;
-						};
-						id=24;
-						type="Cav_B_B_Scout_Rifleman_F";
-						class CustomAttributes
-						{
-							class Attribute0
-							{
-								property="speaker";
-								expression="_this setspeaker _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="STRING";
-										value="Male11ENG";
-									};
-								};
-							};
-							class Attribute1
-							{
-								property="pitch";
-								expression="_this setpitch _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="SCALAR";
-										value=1.04;
-									};
-								};
-							};
-							nAttributes=2;
-						};
-					};
-					class Item4
-					{
-						dataType="Object";
-						class PositionInfo
-						{
-							position[]={-13.739868,0.0014390945,-5.815918};
+							position[]={-13.739746,0.0014390945,-5.8203125};
 						};
 						side="West";
 						flags=5;
@@ -879,7 +830,7 @@ class items
 							description="Alpha Rifleman";
 							isPlayable=1;
 						};
-						id=25;
+						id=1190;
 						type="Cav_B_B_Scout_Alpha_Rifleman_F";
 						class CustomAttributes
 						{
@@ -912,12 +863,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item5
+					class Item4
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-9.7398682,0.0014390945,-1.315918};
+							position[]={-9.7397461,0.0014390945,-1.3203125};
 						};
 						side="West";
 						flags=5;
@@ -929,7 +880,7 @@ class items
 							description="Bravo Team Leader";
 							isPlayable=1;
 						};
-						id=26;
+						id=1191;
 						type="Cav_B_B_Scout_Bravo_TeamLead_F";
 						class CustomAttributes
 						{
@@ -962,12 +913,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item6
+					class Item5
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-9.7398682,0.0014390945,-2.815918};
+							position[]={-9.7397461,0.0014390945,-2.8203125};
 						};
 						side="West";
 						flags=5;
@@ -978,7 +929,7 @@ class items
 							description="Bravo Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=27;
+						id=1192;
 						type="Cav_B_B_Scout_Bravo_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -1011,61 +962,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item7
+					class Item6
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-9.7398682,0.0014390945,-4.315918};
-						};
-						side="West";
-						flags=4;
-						class Attributes
-						{
-							skill=0.40000001;
-							init="this setGroupid [""VIKING-1""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-1""];";
-							description="Bravo Grenadier";
-							isPlayable=1;
-						};
-						id=28;
-						type="Cav_B_B_Scout_Rifleman_F";
-						class CustomAttributes
-						{
-							class Attribute0
-							{
-								property="speaker";
-								expression="_this setspeaker _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="STRING";
-										value="Male07ENG";
-									};
-								};
-							};
-							class Attribute1
-							{
-								property="pitch";
-								expression="_this setpitch _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="SCALAR";
-										value=0.95999998;
-									};
-								};
-							};
-							nAttributes=2;
-						};
-					};
-					class Item8
-					{
-						dataType="Object";
-						class PositionInfo
-						{
-							position[]={-9.7398682,0.0014390945,-5.815918};
+							position[]={-9.7397461,0.0014390945,-5.8203125};
 						};
 						side="West";
 						flags=5;
@@ -1076,7 +978,7 @@ class items
 							description="Bravo Combat Lifesaver";
 							isPlayable=1;
 						};
-						id=29;
+						id=1194;
 						type="Cav_B_B_Scout_Bravo_CombatLifeSaver_F";
 						class CustomAttributes
 						{
@@ -1109,19 +1011,117 @@ class items
 							nAttributes=2;
 						};
 					};
+					class Item7
+					{
+						dataType="Object";
+						class PositionInfo
+						{
+							position[]={-13.739258,0.0014390945,-4.3198242};
+						};
+						side="West";
+						flags=4;
+						class Attributes
+						{
+							skill=0.40000001;
+							init="this setGroupid [""VIKING-1""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-1""];";
+							description="Alpha Grenadier";
+							isPlayable=1;
+						};
+						id=1252;
+						type="Cav_B_B_Scout_Grenadier_F";
+						class CustomAttributes
+						{
+							class Attribute0
+							{
+								property="speaker";
+								expression="_this setspeaker _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="STRING";
+										value="Male11ENG";
+									};
+								};
+							};
+							class Attribute1
+							{
+								property="pitch";
+								expression="_this setpitch _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="SCALAR";
+										value=1.04;
+									};
+								};
+							};
+							nAttributes=2;
+						};
+					};
+					class Item8
+					{
+						dataType="Object";
+						class PositionInfo
+						{
+							position[]={-9.7392578,0.0014390945,-4.3198242};
+						};
+						side="West";
+						flags=4;
+						class Attributes
+						{
+							skill=0.40000001;
+							init="this setGroupid [""VIKING-1""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-1""];";
+							description="Bravo Grenadier";
+							isPlayable=1;
+						};
+						id=1253;
+						type="Cav_B_B_Scout_Grenadier_F";
+						class CustomAttributes
+						{
+							class Attribute0
+							{
+								property="speaker";
+								expression="_this setspeaker _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="STRING";
+										value="Male07ENG";
+									};
+								};
+							};
+							class Attribute1
+							{
+								property="pitch";
+								expression="_this setpitch _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="SCALAR";
+										value=0.95999998;
+									};
+								};
+							};
+							nAttributes=2;
+						};
+					};
 				};
 				class Attributes
 				{
 					dynamicSimulation=1;
 				};
-				id=20;
+				id=1185;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-8.6695557,0.89242268,1.081543};
+					position[]={-8.6694336,0.89242268,1.0771484};
 				};
 				side="Empty";
 				flags=4;
@@ -1130,7 +1130,7 @@ class items
 					init="call{[this,""Bravo"",true,true,true,false,false] call cScripts_fnc_doStarterCrate;}";
 					dynamicSimulation=1;
 				};
-				id=30;
+				id=1195;
 				type="B_supplyCrate_F";
 				class CustomAttributes
 				{
@@ -1181,7 +1181,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-12.602173,2.6142888,7.7290039};
+					position[]={-12.602051,2.6142888,7.7246094};
 				};
 				side="Empty";
 				flags=4;
@@ -1189,7 +1189,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=31;
+				id=1196;
 				type="cav_dragoon_WD_V1";
 				class CustomAttributes
 				{
@@ -1228,7 +1228,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-11.740112,0.0014390945,-2.315918};
+									position[]={-11.740234,0.0014390945,-2.3203125};
 								};
 								side="West";
 								flags=7;
@@ -1239,7 +1239,7 @@ class items
 									description="Stryker Vehicle Commander@SIERRA-1";
 									isPlayable=1;
 								};
-								id=34;
+								id=1199;
 								type="Cav_B_B_Ifv_Commander_F";
 								class CustomAttributes
 								{
@@ -1290,7 +1290,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-11.740112,0.0014390945,-3.815918};
+									position[]={-11.740234,0.0014390945,-3.8203125};
 								};
 								side="West";
 								flags=5;
@@ -1301,7 +1301,7 @@ class items
 									description="Stryker Driver@SIERRA-1";
 									isPlayable=1;
 								};
-								id=35;
+								id=1200;
 								type="Cav_B_B_Ifv_Driver_F";
 								class CustomAttributes
 								{
@@ -1351,13 +1351,13 @@ class items
 						class Attributes
 						{
 						};
-						id=33;
+						id=1198;
 					};
 				};
-				id=32;
+				id=1197;
 			};
 		};
-		id=19;
+		id=1184;
 	};
 	class Item4
 	{
@@ -1378,7 +1378,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-4.151001,0.0014390945,-4.7348633};
+							position[]={-4.1508789,0.0014390945,-4.7392578};
 						};
 						side="West";
 						flags=6;
@@ -1389,7 +1389,7 @@ class items
 							description="Squad Leader@VIKING-2";
 							isPlayable=1;
 						};
-						id=38;
+						id=1203;
 						type="Cav_B_B_Scout_SquadLeader_F";
 						class CustomAttributes
 						{
@@ -1427,7 +1427,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-6.151001,0.0014390945,-5.7348633};
+							position[]={-6.1508789,0.0014390945,-5.7392578};
 						};
 						side="West";
 						flags=5;
@@ -1439,7 +1439,7 @@ class items
 							description="Alpha Team Leader";
 							isPlayable=1;
 						};
-						id=39;
+						id=1204;
 						type="Cav_B_B_Scout_Alpha_TeamLead_F";
 						class CustomAttributes
 						{
@@ -1477,7 +1477,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-6.151001,0.0014390945,-7.2348633};
+							position[]={-6.1508789,0.0014390945,-7.2392578};
 						};
 						side="West";
 						flags=5;
@@ -1488,7 +1488,7 @@ class items
 							description="Alpha Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=40;
+						id=1205;
 						type="Cav_B_B_Scout_Alpha_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -1526,56 +1526,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-6.151001,0.0014390945,-8.7348633};
-						};
-						side="West";
-						flags=4;
-						class Attributes
-						{
-							skill=0.40000001;
-							init="this setGroupid [""VIKING-2""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-2""];";
-							description="Alpha Grenadier";
-							isPlayable=1;
-						};
-						id=41;
-						type="Cav_B_B_Scout_Rifleman_F";
-						class CustomAttributes
-						{
-							class Attribute0
-							{
-								property="speaker";
-								expression="_this setspeaker _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="STRING";
-										value="Male11ENG";
-									};
-								};
-							};
-							class Attribute1
-							{
-								property="pitch";
-								expression="_this setpitch _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="SCALAR";
-										value=1.04;
-									};
-								};
-							};
-							nAttributes=2;
-						};
-					};
-					class Item4
-					{
-						dataType="Object";
-						class PositionInfo
-						{
-							position[]={-6.151001,0.0014390945,-10.234863};
+							position[]={-6.1508789,0.0014390945,-10.239258};
 						};
 						side="West";
 						flags=5;
@@ -1586,7 +1537,7 @@ class items
 							description="Alpha Rifleman";
 							isPlayable=1;
 						};
-						id=42;
+						id=1207;
 						type="Cav_B_B_Scout_Alpha_Rifleman_F";
 						class CustomAttributes
 						{
@@ -1619,12 +1570,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item5
+					class Item4
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-2.151001,0.0014390945,-5.7348633};
+							position[]={-2.1508789,0.0014390945,-5.7392578};
 						};
 						side="West";
 						flags=5;
@@ -1636,7 +1587,7 @@ class items
 							description="Bravo Team Leader";
 							isPlayable=1;
 						};
-						id=43;
+						id=1208;
 						type="Cav_B_B_Scout_Bravo_TeamLead_F";
 						class CustomAttributes
 						{
@@ -1669,12 +1620,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item6
+					class Item5
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-2.151001,0.0014390945,-7.2348633};
+							position[]={-2.1508789,0.0014390945,-7.2392578};
 						};
 						side="West";
 						flags=5;
@@ -1685,7 +1636,7 @@ class items
 							description="Bravo Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=44;
+						id=1209;
 						type="Cav_B_B_Scout_Bravo_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -1718,61 +1669,12 @@ class items
 							nAttributes=2;
 						};
 					};
-					class Item7
+					class Item6
 					{
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={-2.151001,0.0014390945,-8.7348633};
-						};
-						side="West";
-						flags=4;
-						class Attributes
-						{
-							skill=0.40000001;
-							init="this setGroupid [""VIKING-2""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-2""];";
-							description="Bravo Grenadier";
-							isPlayable=1;
-						};
-						id=45;
-						type="Cav_B_B_Scout_Rifleman_F";
-						class CustomAttributes
-						{
-							class Attribute0
-							{
-								property="speaker";
-								expression="_this setspeaker _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="STRING";
-										value="Male07ENG";
-									};
-								};
-							};
-							class Attribute1
-							{
-								property="pitch";
-								expression="_this setpitch _value;";
-								class Value
-								{
-									class data
-									{
-										singleType="SCALAR";
-										value=0.95999998;
-									};
-								};
-							};
-							nAttributes=2;
-						};
-					};
-					class Item8
-					{
-						dataType="Object";
-						class PositionInfo
-						{
-							position[]={-2.151001,0.0014390945,-10.234863};
+							position[]={-2.1508789,0.0014390945,-10.239258};
 						};
 						side="West";
 						flags=5;
@@ -1783,7 +1685,7 @@ class items
 							description="Bravo Combat Lifesaver";
 							isPlayable=1;
 						};
-						id=46;
+						id=1211;
 						type="Cav_B_B_Scout_Bravo_CombatLifeSaver_F";
 						class CustomAttributes
 						{
@@ -1816,19 +1718,117 @@ class items
 							nAttributes=2;
 						};
 					};
+					class Item7
+					{
+						dataType="Object";
+						class PositionInfo
+						{
+							position[]={-6.1513672,0.0014390945,-8.7387695};
+						};
+						side="West";
+						flags=4;
+						class Attributes
+						{
+							skill=0.40000001;
+							init="this setGroupid [""VIKING-2""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-2""];";
+							description="Alpha Grenadier";
+							isPlayable=1;
+						};
+						id=1254;
+						type="Cav_B_B_Scout_Grenadier_F";
+						class CustomAttributes
+						{
+							class Attribute0
+							{
+								property="speaker";
+								expression="_this setspeaker _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="STRING";
+										value="Male11ENG";
+									};
+								};
+							};
+							class Attribute1
+							{
+								property="pitch";
+								expression="_this setpitch _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="SCALAR";
+										value=1.04;
+									};
+								};
+							};
+							nAttributes=2;
+						};
+					};
+					class Item8
+					{
+						dataType="Object";
+						class PositionInfo
+						{
+							position[]={-2.1513672,0.0014390945,-8.7387695};
+						};
+						side="West";
+						flags=4;
+						class Attributes
+						{
+							skill=0.40000001;
+							init="this setGroupid [""VIKING-2""];" \n "this setVariable [""cScripts_Player_Unit"", ""VIKING-2""];";
+							description="Bravo Grenadier";
+							isPlayable=1;
+						};
+						id=1255;
+						type="Cav_B_B_Scout_Grenadier_F";
+						class CustomAttributes
+						{
+							class Attribute0
+							{
+								property="speaker";
+								expression="_this setspeaker _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="STRING";
+										value="Male07ENG";
+									};
+								};
+							};
+							class Attribute1
+							{
+								property="pitch";
+								expression="_this setpitch _value;";
+								class Value
+								{
+									class data
+									{
+										singleType="SCALAR";
+										value=0.95999998;
+									};
+								};
+							};
+							nAttributes=2;
+						};
+					};
 				};
 				class Attributes
 				{
 					dynamicSimulation=1;
 				};
-				id=37;
+				id=1202;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-1.6529541,0.89242268,-2.3500977};
+					position[]={-1.652832,0.89242268,-2.3544922};
 				};
 				side="Empty";
 				flags=4;
@@ -1837,7 +1837,7 @@ class items
 					init="call{[this,""Bravo"",true,true,true,false,false] call cScripts_fnc_doStarterCrate;}";
 					dynamicSimulation=1;
 				};
-				id=47;
+				id=1212;
 				type="B_supplyCrate_F";
 				class CustomAttributes
 				{
@@ -1888,7 +1888,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.8282471,2.6142888,3.5639648};
+					position[]={-4.828125,2.6142888,3.5595703};
 				};
 				side="Empty";
 				flags=4;
@@ -1896,7 +1896,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=48;
+				id=1213;
 				type="cav_dragoon_WD_V2";
 				class CustomAttributes
 				{
@@ -1935,7 +1935,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-4.151001,0.0014390945,-6.7348633};
+									position[]={-4.1508789,0.0014390945,-6.7392578};
 								};
 								side="West";
 								flags=7;
@@ -1946,7 +1946,7 @@ class items
 									description="Stryker Vehicle Commander@SIERRA-2";
 									isPlayable=1;
 								};
-								id=51;
+								id=1216;
 								type="Cav_B_B_Ifv_Commander_F";
 								class CustomAttributes
 								{
@@ -1997,7 +1997,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={-4.151001,0.0014390945,-8.2348633};
+									position[]={-4.1508789,0.0014390945,-8.2392578};
 								};
 								side="West";
 								flags=5;
@@ -2008,7 +2008,7 @@ class items
 									description="Stryker Driver@SIERRA-2";
 									isPlayable=1;
 								};
-								id=52;
+								id=1217;
 								type="Cav_B_B_Ifv_Driver_F";
 								class CustomAttributes
 								{
@@ -2058,13 +2058,13 @@ class items
 						class Attributes
 						{
 						};
-						id=50;
+						id=1215;
 					};
 				};
-				id=49;
+				id=1214;
 			};
 		};
-		id=36;
+		id=1201;
 	};
 	class Item5
 	{
@@ -2085,7 +2085,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={4.348999,0.0014390945,-4.7348633};
+							position[]={4.3491211,0.0014390945,-4.7392578};
 						};
 						side="West";
 						flags=6;
@@ -2096,7 +2096,7 @@ class items
 							description="Squad Leader@VIKING-3";
 							isPlayable=1;
 						};
-						id=55;
+						id=1220;
 						type="Cav_B_B_Scout_SquadLeader_F";
 						class CustomAttributes
 						{
@@ -2134,7 +2134,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.348999,0.0014390945,-5.7348633};
+							position[]={2.3491211,0.0014390945,-5.7392578};
 						};
 						side="West";
 						flags=5;
@@ -2146,7 +2146,7 @@ class items
 							description="Alpha Team Leader";
 							isPlayable=1;
 						};
-						id=56;
+						id=1221;
 						type="Cav_B_B_Scout_Alpha_TeamLead_F";
 						class CustomAttributes
 						{
@@ -2184,7 +2184,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.348999,0.0014390945,-7.2348633};
+							position[]={2.3491211,0.0014390945,-7.2392578};
 						};
 						side="West";
 						flags=5;
@@ -2195,7 +2195,7 @@ class items
 							description="Alpha Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=57;
+						id=1222;
 						type="Cav_B_B_Scout_Alpha_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -2233,7 +2233,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.348999,0.0014390945,-8.7348633};
+							position[]={2.3491211,0.0014390945,-8.7392578};
 						};
 						side="West";
 						flags=4;
@@ -2244,7 +2244,7 @@ class items
 							description="Alpha Grenadier";
 							isPlayable=1;
 						};
-						id=58;
+						id=1223;
 						type="Cav_B_B_Scout_Rifleman_F";
 						class CustomAttributes
 						{
@@ -2282,7 +2282,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={2.348999,0.0014390945,-10.234863};
+							position[]={2.3491211,0.0014390945,-10.239258};
 						};
 						side="West";
 						flags=5;
@@ -2293,7 +2293,7 @@ class items
 							description="Alpha Rifleman";
 							isPlayable=1;
 						};
-						id=59;
+						id=1224;
 						type="Cav_B_B_Scout_Alpha_Rifleman_F";
 						class CustomAttributes
 						{
@@ -2331,7 +2331,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={6.348999,0.0014390945,-5.7348633};
+							position[]={6.3491211,0.0014390945,-5.7392578};
 						};
 						side="West";
 						flags=5;
@@ -2343,7 +2343,7 @@ class items
 							description="Bravo Team Leader";
 							isPlayable=1;
 						};
-						id=60;
+						id=1225;
 						type="Cav_B_B_Scout_Bravo_TeamLead_F";
 						class CustomAttributes
 						{
@@ -2381,7 +2381,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={6.348999,0.0014390945,-7.2348633};
+							position[]={6.3491211,0.0014390945,-7.2392578};
 						};
 						side="West";
 						flags=5;
@@ -2392,7 +2392,7 @@ class items
 							description="Bravo Automatic Rifleman";
 							isPlayable=1;
 						};
-						id=61;
+						id=1226;
 						type="Cav_B_B_Scout_Bravo_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -2430,7 +2430,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={6.348999,0.0014390945,-8.7348633};
+							position[]={6.3491211,0.0014390945,-8.7392578};
 						};
 						side="West";
 						flags=4;
@@ -2441,7 +2441,7 @@ class items
 							description="Bravo Grenadier";
 							isPlayable=1;
 						};
-						id=62;
+						id=1227;
 						type="Cav_B_B_Scout_Rifleman_F";
 						class CustomAttributes
 						{
@@ -2479,7 +2479,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={6.348999,0.0014390945,-10.234863};
+							position[]={6.3491211,0.0014390945,-10.239258};
 						};
 						side="West";
 						flags=5;
@@ -2490,7 +2490,7 @@ class items
 							description="Bravo Combat Lifesaver";
 							isPlayable=1;
 						};
-						id=63;
+						id=1228;
 						type="Cav_B_B_Scout_Bravo_CombatLifeSaver_F";
 						class CustomAttributes
 						{
@@ -2528,14 +2528,14 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=54;
+				id=1219;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={1.5374756,0.89242268,-2.2231445};
+					position[]={1.5375977,0.89242268,-2.2275391};
 				};
 				side="Empty";
 				flags=4;
@@ -2544,7 +2544,7 @@ class items
 					init="call{[this,""Bravo"",true,true,true,false,false] call cScripts_fnc_doStarterCrate;}";
 					dynamicSimulation=1;
 				};
-				id=64;
+				id=1229;
 				type="B_supplyCrate_F";
 				class CustomAttributes
 				{
@@ -2595,7 +2595,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.1112061,2.6142888,3.8120117};
+					position[]={4.1113281,2.6142888,3.8076172};
 				};
 				side="Empty";
 				flags=4;
@@ -2603,7 +2603,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=65;
+				id=1230;
 				type="cav_dragoon_WD_V3";
 				class CustomAttributes
 				{
@@ -2642,7 +2642,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={4.348999,0.0014390945,-6.7348633};
+									position[]={4.3491211,0.0014390945,-6.7392578};
 								};
 								side="West";
 								flags=7;
@@ -2653,7 +2653,7 @@ class items
 									description="Stryker Vehicle Commander@SIERRA-3";
 									isPlayable=1;
 								};
-								id=68;
+								id=1233;
 								type="Cav_B_B_Ifv_Commander_F";
 								class CustomAttributes
 								{
@@ -2704,7 +2704,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={4.348999,0.0014390945,-8.2348633};
+									position[]={4.3491211,0.0014390945,-8.2392578};
 								};
 								side="West";
 								flags=5;
@@ -2715,7 +2715,7 @@ class items
 									description="Stryker Driver@SIERRA-3";
 									isPlayable=1;
 								};
-								id=69;
+								id=1234;
 								type="Cav_B_B_Ifv_Driver_F";
 								class CustomAttributes
 								{
@@ -2765,13 +2765,13 @@ class items
 						class Attributes
 						{
 						};
-						id=67;
+						id=1232;
 					};
 				};
-				id=66;
+				id=1231;
 			};
 		};
-		id=53;
+		id=1218;
 	};
 	class Item6
 	{
@@ -2792,7 +2792,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={11.295288,0.0014390945,-1.1333008};
+							position[]={11.29541,0.0014390945,-1.1376953};
 						};
 						side="West";
 						flags=6;
@@ -2803,7 +2803,7 @@ class items
 							description="Weapons Squad Leader@VIKING-4";
 							isPlayable=1;
 						};
-						id=72;
+						id=1237;
 						type="Cav_B_B_Scout_SquadLeader_F";
 						class CustomAttributes
 						{
@@ -2841,7 +2841,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={9.3486328,0.0014390945,-1.2353516};
+							position[]={9.3486328,0.0014390945,-1.2397461};
 						};
 						side="West";
 						flags=5;
@@ -2853,7 +2853,7 @@ class items
 							description="Alpha Team Leader";
 							isPlayable=1;
 						};
-						id=73;
+						id=1238;
 						type="Cav_B_B_Scout_Alpha_TeamLead_F";
 						class CustomAttributes
 						{
@@ -2891,7 +2891,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={9.3486328,0.0014390945,-2.734375};
+							position[]={9.3486328,0.0014390945,-2.7387695};
 						};
 						side="West";
 						flags=5;
@@ -2902,7 +2902,7 @@ class items
 							description="Alpha Weapons Gunner";
 							isPlayable=1;
 						};
-						id=74;
+						id=1239;
 						type="Cav_B_B_Scout_Alpha_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -2940,7 +2940,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={9.3486328,0.0014390945,-4.234375};
+							position[]={9.3486328,0.0014390945,-4.2387695};
 						};
 						side="West";
 						flags=4;
@@ -2951,7 +2951,7 @@ class items
 							description="Alpha Weapons Assistant";
 							isPlayable=1;
 						};
-						id=75;
+						id=1240;
 						type="Cav_B_B_Scout_Rifleman_F";
 						class CustomAttributes
 						{
@@ -2989,7 +2989,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={13.348633,0.0014390945,-1.2353516};
+							position[]={13.348633,0.0014390945,-1.2397461};
 						};
 						side="West";
 						flags=5;
@@ -3001,7 +3001,7 @@ class items
 							description="Bravo Team Leader";
 							isPlayable=1;
 						};
-						id=76;
+						id=1241;
 						type="Cav_B_B_Scout_Bravo_TeamLead_F";
 						class CustomAttributes
 						{
@@ -3039,7 +3039,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={13.337646,0.0014390945,-2.7460938};
+							position[]={13.337402,0.0014390945,-2.7504883};
 						};
 						side="West";
 						flags=5;
@@ -3050,7 +3050,7 @@ class items
 							description="Bravo Weapons Gunner";
 							isPlayable=1;
 						};
-						id=77;
+						id=1242;
 						type="Cav_B_B_Scout_Bravo_AutomaticRifleman_F";
 						class CustomAttributes
 						{
@@ -3088,7 +3088,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={13.348633,0.0014390945,-4.234375};
+							position[]={13.348633,0.0014390945,-4.2387695};
 						};
 						side="West";
 						flags=4;
@@ -3099,7 +3099,7 @@ class items
 							description="Bravo Weapons Assistant";
 							isPlayable=1;
 						};
-						id=78;
+						id=1243;
 						type="Cav_B_B_Scout_Rifleman_F";
 						class CustomAttributes
 						{
@@ -3137,7 +3137,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={11.403564,0.0014390945,-3.097168};
+							position[]={11.40332,0.0014390945,-3.1015625};
 						};
 						side="West";
 						flags=5;
@@ -3149,7 +3149,7 @@ class items
 							description="Charlie Team Leader";
 							isPlayable=1;
 						};
-						id=79;
+						id=1244;
 						type="Cav_B_B_Scout_Bravo_TeamLead_F";
 						class CustomAttributes
 						{
@@ -3187,7 +3187,7 @@ class items
 						dataType="Object";
 						class PositionInfo
 						{
-							position[]={11.317627,0.0014390945,-4.3793945};
+							position[]={11.317383,0.0014390945,-4.3837891};
 						};
 						side="West";
 						flags=5;
@@ -3198,7 +3198,7 @@ class items
 							description="Charlie Weapons Gunner";
 							isPlayable=1;
 						};
-						id=80;
+						id=1245;
 						type="Cav_B_B_Scout_Bravo_CombatLifeSaver_F";
 						class CustomAttributes
 						{
@@ -3236,14 +3236,14 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=71;
+				id=1236;
 			};
 			class Item1
 			{
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={11.034058,2.6142888,6.7905273};
+					position[]={11.03418,2.6142888,6.7861328};
 				};
 				side="Empty";
 				flags=4;
@@ -3251,7 +3251,7 @@ class items
 				{
 					dynamicSimulation=1;
 				};
-				id=81;
+				id=1246;
 				type="cav_dragoon_WD_V4";
 				class CustomAttributes
 				{
@@ -3290,7 +3290,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={12.263306,0.0014390945,-5.9130859};
+									position[]={12.263184,0.0014390945,-5.9174805};
 								};
 								side="West";
 								flags=7;
@@ -3301,7 +3301,7 @@ class items
 									description="Stryker Vehicle Commander@SIERRA-4";
 									isPlayable=1;
 								};
-								id=84;
+								id=1249;
 								type="Cav_B_B_Ifv_Commander_F";
 								class CustomAttributes
 								{
@@ -3352,7 +3352,7 @@ class items
 								dataType="Object";
 								class PositionInfo
 								{
-									position[]={10.369019,0.0014390945,-5.8530273};
+									position[]={10.369141,0.0014390945,-5.8574219};
 								};
 								side="West";
 								flags=5;
@@ -3363,7 +3363,7 @@ class items
 									description="Stryker Driver@SIERRA-4";
 									isPlayable=1;
 								};
-								id=85;
+								id=1250;
 								type="Cav_B_B_Ifv_Driver_F";
 								class CustomAttributes
 								{
@@ -3413,12 +3413,12 @@ class items
 						class Attributes
 						{
 						};
-						id=83;
+						id=1248;
 					};
 				};
-				id=82;
+				id=1247;
 			};
 		};
-		id=70;
+		id=1235;
 	};
 };


### PR DESCRIPTION
Viking squads had riflemens as base units instead of the grenadiers in most of their squads which made them load in with rifleman loadouts instead of grenadier loadouts.
